### PR TITLE
Change initial getAllConvertHistory position

### DIFF
--- a/app/src/main/java/ksnd/open/hiraganaconverter/view/dialog/ConvertHistoryDialog.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/view/dialog/ConvertHistoryDialog.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -81,6 +82,11 @@ private fun ConvertHistoryDialogContent(
     onCloseClick: () -> Unit,
     viewModel: ConvertHistoryViewModel
 ) {
+
+    LaunchedEffect(true) {
+        viewModel.getAllConvertHistory()
+    }
+
     Scaffold(
         modifier = Modifier
             .fillMaxHeight(0.95f)

--- a/app/src/main/java/ksnd/open/hiraganaconverter/viewmodel/ConvertHistoryViewModel.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/viewmodel/ConvertHistoryViewModel.kt
@@ -8,4 +8,5 @@ abstract class ConvertHistoryViewModel : ViewModel() {
     abstract val convertHistories: MutableState<List<ConvertHistoryData>>
     abstract fun deleteAllConvertHistory()
     abstract fun deleteConvertHistory(id: Long)
+    abstract fun getAllConvertHistory()
 }

--- a/app/src/main/java/ksnd/open/hiraganaconverter/viewmodel/ConvertHistoryViewModelImpl.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/viewmodel/ConvertHistoryViewModelImpl.kt
@@ -15,10 +15,6 @@ class ConvertHistoryViewModelImpl @Inject constructor(
     private val convertHistoryRepository: ConvertHistoryRepository
 ) : ConvertHistoryViewModel() {
 
-    init {
-        getAllConvertHistory()
-    }
-
     override val convertHistories: MutableState<List<ConvertHistoryData>> =
         mutableStateOf(emptyList())
 
@@ -37,7 +33,7 @@ class ConvertHistoryViewModelImpl @Inject constructor(
         }
     }
 
-    private fun getAllConvertHistory() {
+    override fun getAllConvertHistory() {
         CoroutineScope(Dispatchers.IO).launch {
             convertHistories.value = convertHistoryRepository
                 .getAllConvertHistory()

--- a/app/src/main/java/ksnd/open/hiraganaconverter/viewmodel/PreviewViewModel.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/viewmodel/PreviewViewModel.kt
@@ -61,4 +61,5 @@ class PreviewConvertHistoryViewModel(isNoData: Boolean = false) : ConvertHistory
     )
     override fun deleteAllConvertHistory() {}
     override fun deleteConvertHistory(id: Long) {}
+    override fun getAllConvertHistory() {}
 }


### PR DESCRIPTION
## エラー
起動してすぐに履歴の画面に遷移しようとすると以下のエラーが発生し落ちる。
java.lang.IllegalStateException: Reading a state that was created after the snapshot was taken or in a snapshot that has not yet been applied

## 変更内容
履歴表示する際に最初に履歴取得する処理の宣言位置をviewModelからscreen（Composable）に変更した

## 参考サイト
https://stackoverflow.com/questions/66891349/java-lang-illegalstateexception-when-using-state-in-android-jetpack-compose