### PR TITLE
apply kotlinx-serialization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("kotlin-kapt")
     id("dagger.hilt.android.plugin")
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.7.10"
 }
 
 android {
@@ -78,22 +79,17 @@ dependencies {
     implementation("androidx.compose.material3:material3:1.1.0-alpha02")
 
     // accompanist
-    implementation("com.google.accompanist:accompanist-systemuicontroller:0.23.1")
+    implementation("com.google.accompanist:accompanist-systemuicontroller:0.28.0")
 
     // COIL
     implementation("io.coil-kt:coil-compose:2.2.2")
 
     // Retrofit
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
-    implementation("com.squareup.retrofit2:converter-gson:2.6.0")
-
-    // moshi
-    implementation("com.squareup.retrofit2:converter-moshi:2.9.0")
-    implementation("com.squareup.moshi:moshi-kotlin:1.14.0")
 
     // Hilt
-    implementation("com.google.dagger:hilt-android:2.43.2")
-    kapt("com.google.dagger:hilt-compiler:2.43.2")
+    implementation("com.google.dagger:hilt-android:2.44.2")
+    kapt("com.google.dagger:hilt-compiler:2.44.2")
     implementation("androidx.hilt:hilt-navigation-compose:1.0.0")
 
     // dataStore preferences
@@ -114,6 +110,10 @@ dependencies {
     // Robolectric environment
     testImplementation("androidx.test:core:1.5.0")
     testImplementation("org.robolectric:robolectric:4.9")
+
+    // kotlinx serialization
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
+    implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0")
 }
 
 // チェック

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,30 +1,64 @@
-#### 以下のURLを参考
-#### [URL] https://github.com/square/moshi/issues/345
+# ■ OkHttp の設定 -----------------------------------------------------------------------------------
 
-#### OkHttp, Retrofit and Moshi
--dontwarn okhttp3.**
--dontwarn retrofit2.Platform.**
--dontwarn okio.**
+# 以下を参考
+#https://square.github.io/okhttp/features/r8_proguard/
+
+# nullability情報を埋め込むためのJSR 305アノテーションの警告を無視するための設定
 -dontwarn javax.annotation.**
--keepclasseswithmembers class * {
+# リソースは相対パスでロードするため、このクラスのパッケージを保存するための設定
+-adaptresourcefilenames okhttp3/internal/publicsuffix/PublicSuffixDatabase.gz
+
+
+# ■ Retrofitの設定 ----------------------------------------------------------------------------------
+
+# 以下を参考
+# https://github.com/square/retrofit/blob/master/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+
+# Retrofitはジェネリックパラメータにリフレクションを行う。Signatureを使うにはInnerClassesが必要。
+# InnerClassesを使うにはEnclosingMethodが必要
+-keepattributes Signature, InnerClasses, EnclosingMethod
+# Retrofitでメソッドとパラメータのアノテーションのリフレクションを行うための設定
+-keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
+# アノテーションのデフォルト値を保持する
+-keepattributes AnnotationDefault
+# Serviceのメソッドのパラメータを保持するための設定
+-keepclasseswithmembers interface * {
     @retrofit2.http.* <methods>;
 }
--keepclasseswithmembers class * {
-    @com.squareup.moshi.* <methods>;
-}
--keep @com.squareup.moshi.JsonQualifier interface *
--dontwarn org.jetbrains.annotations.**
--keep class kotlin.Metadata { *; }
--keep class kotlin.Metadata {
-    public <methods>;
-}
+# Kotlinでのみ使用できるトップレベルの関数の警告を無視するための設定
+-dontwarn retrofit2.KotlinExtensions
+-dontwarn retrofit2.KotlinExtensions$*
+# 継承したServiceを保持するための設定
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface * extends <1>
+# CallとResponseのジェネリックのシグネチャを保持する
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
 
--keepclassmembers class * {
-    @com.squareup.moshi.FromJson <methods>;
-    @com.squareup.moshi.ToJson <methods>;
+
+# ■ kotlinx.serializationの設定 ---------------------------------------------------------------------
+
+# 以下を参考
+# https://github.com/Kotlin/kotlinx.serialization#android
+
+# NoClassDefFoundError kotlinx.serialization.json.JsonObjectSerializerがある場合に使用する設定
+-keepclassmembers class kotlinx.serialization.json.** {
+    *** Companion;
 }
-
--keepnames @kotlin.Metadata class ksnd.open.hiraganaconverter.model.**
--keep class ksnd.open.hiraganaconverter.model.** { *; }
--keepclassmembers class ksnd.open.hiraganaconverter.model.** { *; }
-
+-keepclasseswithmembers class kotlinx.serialization.json.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+# アプリ固有のもの
+# Change here com.yourcompany.yourpackage
+-keepclassmembers @kotlinx.serialization.Serializable class ksnd.open.hiraganaconverter.model.** {
+    # lookup for plugin generated serializable classes
+    *** Companion;
+    # lookup for serializable objects
+    *** INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+# lookup for plugin generated serializable classes
+-if @kotlinx.serialization.Serializable class ksnd.open.hiraganaconverter.model.**
+-keepclassmembers class ksnd.open.hiraganaconverter.model.<1>$Companion {
+    kotlinx.serialization.KSerializer serializer(...);
+}

--- a/app/src/main/java/ksnd/open/hiraganaconverter/model/RequestData.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/model/RequestData.kt
@@ -1,20 +1,20 @@
 package ksnd.open.hiraganaconverter.model
 
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
-@JsonClass(generateAdapter = false)
+@Serializable
 data class RequestData(
 
     /** アプリケーションID */
-    @Json(name = "app_id")
+    @SerialName("app_id")
     val appId: String,
 
     /** 解析対象テキスト */
-    @Json(name = "sentence")
+    @SerialName("sentence")
     val sentence: String,
 
     /** 出力タイプ */
-    @Json(name = "output_type")
+    @SerialName("output_type")
     val outputType: String
 )

--- a/app/src/main/java/ksnd/open/hiraganaconverter/model/ResponseData.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/model/ResponseData.kt
@@ -1,20 +1,20 @@
 package ksnd.open.hiraganaconverter.model
 
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
-@JsonClass(generateAdapter = false)
+@Serializable
 data class ResponseData(
 
     /** リクエストID */
-    @Json(name = "request_id")
+    @SerialName("request_id")
     val requestId: String,
 
     /** 出力タイプ */
-    @Json(name = "output_type")
+    @SerialName("output_type")
     val outputType: String,
 
     /** 変換後文字列 */
-    @Json(name = "converted")
+    @SerialName("converted")
     val converted: String
 )

--- a/app/src/main/java/ksnd/open/hiraganaconverter/model/repository/ConvertRepositoryImpl.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/model/repository/ConvertRepositoryImpl.kt
@@ -1,16 +1,18 @@
 package ksnd.open.hiraganaconverter.model.repository
 
 import android.util.Log
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import ksnd.open.hiraganaconverter.model.ConvertApiClient
 import ksnd.open.hiraganaconverter.model.RequestData
 import ksnd.open.hiraganaconverter.model.ResponseData
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
 import retrofit2.Response
 import retrofit2.Retrofit
-import retrofit2.converter.moshi.MoshiConverterFactory
 import java.io.IOException
 import javax.inject.Inject
 
@@ -18,15 +20,12 @@ class ConvertRepositoryImpl @Inject constructor() : ConvertRepository {
 
     private val tag = ConvertRepositoryImpl::class.java.simpleName
 
-    // JSONからKotlinのクラスに変換するためのライブラリの設定
-    private val moshi = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
+    private val contentType = "application/json".toMediaType()
 
-    // REST APIを利用するためのライブラリの設定
+    @OptIn(ExperimentalSerializationApi::class)
     private val retrofit = Retrofit.Builder()
         .baseUrl("https://labs.goo.ne.jp/api/hiragana/")
-        .addConverterFactory(MoshiConverterFactory.create(moshi))
+        .addConverterFactory(Json.asConverterFactory(contentType))
         .build()
 
     // ApiClientに定義したメソッドを呼び出すための設定
@@ -44,7 +43,7 @@ class ConvertRepositoryImpl @Inject constructor() : ConvertRepository {
                 sentence = sentence,
                 outputType = type
             )
-            val json = moshi.adapter(RequestData::class.java).toJson(requestData)
+            val json = Json.encodeToString(requestData)
             Log.i(tag, "json: $json")
             val body = json.toRequestBody(
                 contentType = "application/json; charset=utf-8".toMediaTypeOrNull()


### PR DESCRIPTION
- #42 のプルリクエスト
moshiからkotlinx.serializationへ置き換え
一部ライブラリのバージョンも同時に上げた。
Proguardは全面的に見直した（内部テストでAPI通信ができることは確認済み）

## Proguardについて以下を参考にした
DroidKaigi2018: なんとなく動いているProGuardから脱出するために
https://docs.google.com/presentation/d/1r53A3Qr4j7GetCaq7LbvVSFKlPdKdCvn4M08AWM16N8/edit#slide=id.p
Proguard設定のメモ
https://qiita.com/boohbah/items/7372b29637d28e6d671c#-keep%E3%81%A8-keepnames%E3%81%AE%E9%81%95%E3%81%84


#### 以下メモ
<-dontwarnの説明>
参照先のクラスが存在しないというワーニングを出さないための設定

<keepの説明>
shrinkと難読化を防ぐための設定(後ろに'names'がつくと難読化のみを防ぐ（keepattributes以外）)
-keep クラス、メンバー
-keepclassmembers メンバー
-keepclassedwithmemembers メンバーがある時のクラス、メンバー
-keepattributes メタデータ（アノテーション, Exception、ジェネリクスの型パラメータ、ファイル）
