### PR TITLE
#59(privateで散らばっているComposableの移動など)の追加

### DIFF
--- a/app/src/main/java/ksnd/open/hiraganaconverter/view/dialog/ConvertHistoryDetailDialog.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/view/dialog/ConvertHistoryDetailDialog.kt
@@ -36,6 +36,7 @@ import ksnd.open.hiraganaconverter.R
 import ksnd.open.hiraganaconverter.model.ConvertHistoryData
 import ksnd.open.hiraganaconverter.view.parts.button.BottomCloseButton
 import ksnd.open.hiraganaconverter.view.parts.button.CustomFilledTonalIconButton
+import ksnd.open.hiraganaconverter.view.theme.HiraganaConverterTheme
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -165,16 +166,36 @@ private fun BeforeOrAfterText(
 
 @Preview
 @Composable
-private fun PreviewConvertHistoryDetailDialogContent() {
-    Box(modifier = Modifier.fillMaxSize()) {
-        ConvertHistoryDetailDialogContent(
-            onCloseClick = {},
-            historyData = ConvertHistoryData(
-                id = 0,
-                time = "2022/11/26 22:25",
-                before = "変換前はこんな感じ",
-                after = "へんかんごはこんなかんじ",
-            ),
-        )
+private fun PreviewConvertHistoryDetailDialogContent_Light() {
+    HiraganaConverterTheme(isDarkTheme = false) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            ConvertHistoryDetailDialogContent(
+                onCloseClick = {},
+                historyData = ConvertHistoryData(
+                    id = 0,
+                    time = "2022/11/26 22:25",
+                    before = "変換前はこんな感じ",
+                    after = "へんかんごはこんなかんじ",
+                ),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewConvertHistoryDetailDialogContent_Dark() {
+    HiraganaConverterTheme(isDarkTheme = true) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            ConvertHistoryDetailDialogContent(
+                onCloseClick = {},
+                historyData = ConvertHistoryData(
+                    id = 0,
+                    time = "2022/11/26 22:25",
+                    before = "変換前はこんな感じ",
+                    after = "へんかんごはこんなかんじ",
+                ),
+            )
+        }
     }
 }

--- a/app/src/main/java/ksnd/open/hiraganaconverter/view/dialog/MovesToSiteDialog.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/view/dialog/MovesToSiteDialog.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import ksnd.open.hiraganaconverter.R
+import ksnd.open.hiraganaconverter.view.theme.HiraganaConverterTheme
 
 @Composable
 fun MovesToSiteDialog(onDismissRequest: () -> Unit, onClick: () -> Unit, url: String) {
@@ -33,10 +34,24 @@ fun MovesToSiteDialog(onDismissRequest: () -> Unit, onClick: () -> Unit, url: St
 
 @Preview
 @Composable
-private fun PreviewMovesToSiteDialog() {
-    MovesToSiteDialog(
-        onDismissRequest = {},
-        onClick = {},
-        url = "架空のURL",
-    )
+private fun PreviewMovesToSiteDialog_Light() {
+    HiraganaConverterTheme(isDarkTheme = false) {
+        MovesToSiteDialog(
+            onDismissRequest = {},
+            onClick = {},
+            url = "架空のURL",
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewMovesToSiteDialog_Dark() {
+    HiraganaConverterTheme(isDarkTheme = true) {
+        MovesToSiteDialog(
+            onDismissRequest = {},
+            onClick = {},
+            url = "架空のURL",
+        )
+    }
 }

--- a/app/src/main/java/ksnd/open/hiraganaconverter/view/dialog/SelectLanguageDialog.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/view/dialog/SelectLanguageDialog.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Surface
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -25,6 +26,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import ksnd.open.hiraganaconverter.R
 import ksnd.open.hiraganaconverter.view.parts.button.BottomCloseButton
 import ksnd.open.hiraganaconverter.view.parts.card.LanguageCard
+import ksnd.open.hiraganaconverter.view.theme.HiraganaConverterTheme
 import ksnd.open.hiraganaconverter.viewmodel.PreviewSelectLanguageViewModel
 import ksnd.open.hiraganaconverter.viewmodel.SelectLanguageViewModel
 import ksnd.open.hiraganaconverter.viewmodel.SelectLanguageViewModelImpl
@@ -85,9 +87,26 @@ private fun SelectLanguageDialogContent(
 
 @Preview
 @Composable
-private fun PreviewSelectLanguageDialogContent() {
-    SelectLanguageDialogContent(
-        onCloseClick = {},
-        PreviewSelectLanguageViewModel(),
-    )
+private fun PreviewSelectLanguageDialogContent_Light() {
+    HiraganaConverterTheme(isDarkTheme = false) {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            SelectLanguageDialogContent(
+                onCloseClick = {},
+                PreviewSelectLanguageViewModel(),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewSelectLanguageDialogContent_Dark() {
+    HiraganaConverterTheme(isDarkTheme = true) {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            SelectLanguageDialogContent(
+                onCloseClick = {},
+                PreviewSelectLanguageViewModel(),
+            )
+        }
+    }
 }

--- a/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/button/BottomCloseButton.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/button/BottomCloseButton.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -20,6 +21,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ksnd.open.hiraganaconverter.R
 import ksnd.open.hiraganaconverter.view.rememberButtonScaleState
+import ksnd.open.hiraganaconverter.view.theme.HiraganaConverterTheme
 
 @Composable
 fun BottomCloseButton(
@@ -56,6 +58,20 @@ fun BottomCloseButton(
 
 @Preview
 @Composable
-private fun PreviewBottomComposableButton() {
-    BottomCloseButton {}
+private fun PreviewBottomComposableButton_Light() {
+    HiraganaConverterTheme(isDarkTheme = false) {
+        Surface(color = MaterialTheme.colorScheme.surface) {
+            BottomCloseButton {}
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBottomComposableButton_Dark() {
+    HiraganaConverterTheme(isDarkTheme = true) {
+        Surface(color = MaterialTheme.colorScheme.surface) {
+            BottomCloseButton {}
+        }
+    }
 }

--- a/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/button/ConvertButton.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/button/ConvertButton.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -20,9 +21,11 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ksnd.open.hiraganaconverter.R
 import ksnd.open.hiraganaconverter.view.rememberButtonScaleState
+import ksnd.open.hiraganaconverter.view.theme.HiraganaConverterTheme
 
 @Composable
 fun ConvertButton(onClick: () -> Unit) {
@@ -60,6 +63,26 @@ fun ConvertButton(onClick: () -> Unit) {
                 color = MaterialTheme.colorScheme.onPrimaryContainer,
                 modifier = Modifier.padding(start = 8.dp),
             )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewConvertButton_Light() {
+    HiraganaConverterTheme(isDarkTheme = false) {
+        Surface(color = MaterialTheme.colorScheme.surface) {
+            ConvertButton {}
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewConvertButton_Dark() {
+    HiraganaConverterTheme(isDarkTheme = true) {
+        Surface(color = MaterialTheme.colorScheme.surface) {
+            ConvertButton {}
         }
     }
 }

--- a/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/button/CustomFilledTonalIconButton.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/button/CustomFilledTonalIconButton.kt
@@ -4,14 +4,19 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import ksnd.open.hiraganaconverter.R
 import ksnd.open.hiraganaconverter.view.rememberButtonScaleState
+import ksnd.open.hiraganaconverter.view.theme.HiraganaConverterTheme
 
 @Composable
 fun CustomFilledTonalIconButton(
@@ -35,5 +40,33 @@ fun CustomFilledTonalIconButton(
             contentScale = ContentScale.Fit,
             modifier = Modifier.size(24.dp),
         )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewConvertButton_Light() {
+    HiraganaConverterTheme(isDarkTheme = false) {
+        Surface(color = MaterialTheme.colorScheme.surface) {
+            CustomFilledTonalIconButton(
+                contentDescription = "",
+                painter = painterResource(id = R.drawable.ic_baseline_content_copy_24),
+                onClick = {},
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewConvertButton_Dark() {
+    HiraganaConverterTheme(isDarkTheme = true) {
+        Surface(color = MaterialTheme.colorScheme.surface) {
+            CustomFilledTonalIconButton(
+                contentDescription = "",
+                painter = painterResource(id = R.drawable.ic_baseline_content_copy_24),
+                onClick = {},
+            )
+        }
     }
 }

--- a/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/button/MoveTopButton.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/button/MoveTopButton.kt
@@ -7,7 +7,9 @@ import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideIn
 import androidx.compose.animation.slideOut
 import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -16,12 +18,15 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import ksnd.open.hiraganaconverter.R
+import ksnd.open.hiraganaconverter.view.theme.HiraganaConverterTheme
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
@@ -50,6 +55,34 @@ fun MoveTopButton(scrollState: ScrollState) {
                 color = MaterialTheme.colorScheme.onPrimaryContainer,
                 style = MaterialTheme.typography.bodyLarge,
             )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewMoveTopButton_Light() {
+    HiraganaConverterTheme(isDarkTheme = false) {
+        val scrollState = rememberScrollState(initial = 1)
+        Box(
+            modifier = Modifier.padding(all = 16.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            MoveTopButton(scrollState = scrollState)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewMoveTopButton_Dark() {
+    HiraganaConverterTheme(isDarkTheme = true) {
+        val scrollState = rememberScrollState(initial = 1)
+        Box(
+            modifier = Modifier.padding(all = 16.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            MoveTopButton(scrollState = scrollState)
         }
     }
 }

--- a/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/card/ConversionTypeSpinnerCard.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/card/ConversionTypeSpinnerCard.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import ksnd.open.hiraganaconverter.R
 import ksnd.open.hiraganaconverter.model.HiraKanaType
 import ksnd.open.hiraganaconverter.view.rememberButtonScaleState
+import ksnd.open.hiraganaconverter.view.theme.HiraganaConverterTheme
 
 @Composable
 fun ConversionTypeSpinnerCard(
@@ -115,6 +116,16 @@ fun ConversionTypeSpinnerCard(
 
 @Preview
 @Composable
-private fun PreviewConversionTypeSpinnerCard() {
-    ConversionTypeSpinnerCard(onSelectedChange = {})
+private fun PreviewConversionTypeSpinnerCard_Light() {
+    HiraganaConverterTheme(isDarkTheme = false) {
+        ConversionTypeSpinnerCard(onSelectedChange = {})
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewConversionTypeSpinnerCard_Dark() {
+    HiraganaConverterTheme(isDarkTheme = true) {
+        ConversionTypeSpinnerCard(onSelectedChange = {})
+    }
 }

--- a/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/card/CovertHistoryCard.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/card/CovertHistoryCard.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ksnd.open.hiraganaconverter.view.rememberButtonScaleState
+import ksnd.open.hiraganaconverter.view.theme.HiraganaConverterTheme
 
 @Composable
 fun ConvertHistoryCard(
@@ -97,11 +98,26 @@ private fun ConvertHistoryCardTimeText(timeText: String) {
 
 @Preview
 @Composable
-private fun PreviewConvertHistoryCard() {
-    ConvertHistoryCard(
-        beforeText = "変換前文章",
-        time = "2022/12/29 18:19",
-        onClick = {},
-        onDeleteClick = {},
-    )
+private fun PreviewConvertHistoryCard_Light() {
+    HiraganaConverterTheme(isDarkTheme = false) {
+        ConvertHistoryCard(
+            beforeText = "変換前文章",
+            time = "2022/12/29 18:19",
+            onClick = {},
+            onDeleteClick = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewConvertHistoryCard_Dark() {
+    HiraganaConverterTheme(isDarkTheme = true) {
+        ConvertHistoryCard(
+            beforeText = "変換前文章",
+            time = "2022/12/29 18:19",
+            onClick = {},
+            onDeleteClick = {},
+        )
+    }
 }

--- a/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/card/ErrorCard.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/card/ErrorCard.kt
@@ -1,0 +1,82 @@
+package ksnd.open.hiraganaconverter.view.parts.card
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ksnd.open.hiraganaconverter.R
+import ksnd.open.hiraganaconverter.view.rememberButtonScaleState
+import ksnd.open.hiraganaconverter.view.theme.HiraganaConverterTheme
+
+@Composable
+fun ErrorCard(
+    errorText: String,
+    onClick: () -> Unit,
+) {
+    val buttonScaleState = rememberButtonScaleState()
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(all = 16.dp)
+            .scale(scale = buttonScaleState.animationScale.value)
+            .clickable(
+                interactionSource = buttonScaleState.interactionSource,
+                indication = null,
+                onClick = onClick,
+            ),
+        colors = CardDefaults.outlinedCardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+        ),
+        border = BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.error),
+    ) {
+        Row(
+            modifier = Modifier.padding(all = 16.dp),
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_baseline_error_outline_24),
+                contentDescription = "convert",
+                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.error),
+                contentScale = ContentScale.Fit,
+                modifier = Modifier.size(36.dp),
+            )
+            Text(
+                text = errorText,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(start = 8.dp),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewErrorCard_Light() {
+    HiraganaConverterTheme(isDarkTheme = false) {
+        ErrorCard(errorText = stringResource(id = R.string.limit_exceeded), onClick = {})
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewErrorCard_Dark() {
+    HiraganaConverterTheme(isDarkTheme = true) {
+        ErrorCard(errorText = stringResource(id = R.string.conversion_failed), onClick = {})
+    }
+}

--- a/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/card/LanguageCard.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/view/parts/card/LanguageCard.kt
@@ -26,6 +26,7 @@ import androidx.core.content.ContextCompat
 import ksnd.open.hiraganaconverter.R
 import ksnd.open.hiraganaconverter.view.MainActivity
 import ksnd.open.hiraganaconverter.view.rememberButtonScaleState
+import ksnd.open.hiraganaconverter.view.theme.HiraganaConverterTheme
 
 @Composable
 fun LanguageCard(
@@ -73,13 +74,30 @@ fun LanguageCard(
 
 @Preview
 @Composable
-private fun PreviewLanguageCard_Night() {
+private fun PreviewLanguageCard_Light() {
     val displayLanguageList = stringArrayResource(id = R.array.display_language)
-    Column(Modifier.fillMaxWidth()) {
-        LanguageCard(
-            onNewLanguageClick = {},
-            index = 0,
-            displayLanguage = displayLanguageList[0],
-        )
+    HiraganaConverterTheme(isDarkTheme = false) {
+        Column(Modifier.fillMaxWidth()) {
+            LanguageCard(
+                onNewLanguageClick = {},
+                index = 0,
+                displayLanguage = displayLanguageList[0],
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewLanguageCard_Dark() {
+    val displayLanguageList = stringArrayResource(id = R.array.display_language)
+    HiraganaConverterTheme(isDarkTheme = true) {
+        Column(Modifier.fillMaxWidth()) {
+            LanguageCard(
+                onNewLanguageClick = {},
+                index = 0,
+                displayLanguage = displayLanguageList[0],
+            )
+        }
     }
 }

--- a/app/src/main/java/ksnd/open/hiraganaconverter/view/screen/ConverterScreen.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/view/screen/ConverterScreen.kt
@@ -1,9 +1,6 @@
 package ksnd.open.hiraganaconverter.view.screen
 
 import android.widget.Toast
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,10 +17,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.TextFieldDefaults
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -34,12 +29,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.FocusManager
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
@@ -57,7 +49,7 @@ import ksnd.open.hiraganaconverter.view.parts.button.ConvertButton
 import ksnd.open.hiraganaconverter.view.parts.button.CustomFilledTonalIconButton
 import ksnd.open.hiraganaconverter.view.parts.button.MoveTopButton
 import ksnd.open.hiraganaconverter.view.parts.card.ConversionTypeSpinnerCard
-import ksnd.open.hiraganaconverter.view.rememberButtonScaleState
+import ksnd.open.hiraganaconverter.view.parts.card.ErrorCard
 import ksnd.open.hiraganaconverter.viewmodel.ConvertViewModel
 import ksnd.open.hiraganaconverter.viewmodel.ConvertViewModelImpl
 import ksnd.open.hiraganaconverter.viewmodel.PreviewConvertViewModel
@@ -150,47 +142,6 @@ private fun ConverterScreenContent(viewModel: ConvertViewModel) {
             )
 
             Spacer(modifier = Modifier.height(120.dp))
-        }
-    }
-}
-
-@Composable
-private fun ErrorCard(
-    errorText: String,
-    onClick: () -> Unit,
-) {
-    val buttonScaleState = rememberButtonScaleState()
-    OutlinedCard(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(all = 16.dp)
-            .scale(scale = buttonScaleState.animationScale.value)
-            .clickable(
-                interactionSource = buttonScaleState.interactionSource,
-                indication = null,
-                onClick = onClick,
-            ),
-        colors = CardDefaults.outlinedCardColors(
-            containerColor = MaterialTheme.colorScheme.errorContainer,
-        ),
-        border = BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.error),
-    ) {
-        Row(
-            modifier = Modifier.padding(all = 16.dp),
-        ) {
-            Image(
-                painter = painterResource(id = R.drawable.ic_baseline_error_outline_24),
-                contentDescription = "convert",
-                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.error),
-                contentScale = ContentScale.Fit,
-                modifier = Modifier.size(36.dp),
-            )
-            Text(
-                text = errorText,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.error,
-                modifier = Modifier.padding(start = 8.dp),
-            )
         }
     }
 }

--- a/app/src/main/java/ksnd/open/hiraganaconverter/view/screen/ConverterScreen.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/view/screen/ConverterScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.verticalScroll
@@ -121,8 +120,9 @@ private fun ConverterScreenContent(viewModel: ConvertViewModel) {
                 )
             }
 
-            BeforeTextField(
-                inputText = convertUiState.inputText,
+            BeforeOrAfterTextField(
+                isBefore = true,
+                text = convertUiState.inputText,
                 clipboardManager = clipboardManager,
                 focusManager = focusManager,
                 onValueChange = viewModel::updateInputText,
@@ -134,8 +134,9 @@ private fun ConverterScreenContent(viewModel: ConvertViewModel) {
                 modifier = Modifier.padding(vertical = 8.dp, horizontal = 50.dp),
             )
 
-            AfterTextField(
-                outputText = convertUiState.outputText,
+            BeforeOrAfterTextField(
+                isBefore = false,
+                text = convertUiState.outputText,
                 clipboardManager = clipboardManager,
                 focusManager = focusManager,
                 onValueChange = viewModel::updateOutputText,
@@ -147,8 +148,9 @@ private fun ConverterScreenContent(viewModel: ConvertViewModel) {
 }
 
 @Composable
-private fun BeforeTextField(
-    inputText: String,
+private fun BeforeOrAfterTextField(
+    isBefore: Boolean,
+    text: String,
     clipboardManager: ClipboardManager,
     focusManager: FocusManager,
     onValueChange: (String) -> Unit,
@@ -156,11 +158,13 @@ private fun BeforeTextField(
     val context = LocalContext.current
     Row {
         Text(
-            text = "[ ${stringResource(id = R.string.before_conversion)} ]",
+            text = if (isBefore) {
+                String.format("[ %s ]", stringResource(id = R.string.before_conversion))
+            } else {
+                String.format("[ %s ]", stringResource(id = R.string.after_conversion))
+            },
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier
-                .padding(all = 16.dp)
-                .weight(1f),
+            modifier = Modifier.padding(all = 16.dp).weight(1f),
             color = MaterialTheme.colorScheme.onSurface,
         )
 
@@ -169,80 +173,40 @@ private fun BeforeTextField(
             contentDescription = "copyText",
             painter = painterResource(id = R.drawable.ic_baseline_content_copy_24),
             onClick = {
-                clipboardManager.setText(AnnotatedString(inputText))
+                clipboardManager.setText(AnnotatedString(text))
                 Toast.makeText(context, "COPIED.", Toast.LENGTH_SHORT).show()
             },
         )
     }
     OutlinedTextField(
-        value = inputText,
+        value = text,
         onValueChange = onValueChange,
         keyboardActions = KeyboardActions {
             focusManager.clearFocus()
         },
         textStyle = MaterialTheme.typography.titleMedium,
         colors = TextFieldDefaults.outlinedTextFieldColors(
-            textColor = MaterialTheme.colorScheme.secondary,
-            unfocusedBorderColor = MaterialTheme.colorScheme.surface,
-            focusedBorderColor = MaterialTheme.colorScheme.surface,
-        ),
-        placeholder = {
-            Text(
-                text = stringResource(id = R.string.input_hint),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.secondary,
-            )
-        },
-        modifier = Modifier
-            .defaultMinSize(minHeight = 120.dp)
-            .fillMaxWidth(),
-    )
-}
-
-@Composable
-private fun AfterTextField(
-    outputText: String,
-    clipboardManager: ClipboardManager,
-    focusManager: FocusManager,
-    onValueChange: (String) -> Unit,
-) {
-    val context = LocalContext.current
-    Row {
-        Text(
-            text = "[ ${stringResource(id = R.string.after_conversion)} ]",
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier
-                .padding(all = 16.dp)
-                .weight(1f),
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-        CustomFilledTonalIconButton(
-            modifier = Modifier
-                .padding(top = 16.dp, bottom = 16.dp, end = 16.dp)
-                .size(48.dp),
-            contentDescription = "copyText",
-            painter = painterResource(id = R.drawable.ic_baseline_content_copy_24),
-            onClick = {
-                clipboardManager.setText(AnnotatedString(outputText))
-                Toast.makeText(context, "COPIED.", Toast.LENGTH_SHORT).show()
+            textColor = if (isBefore) {
+                MaterialTheme.colorScheme.secondary
+            } else {
+                MaterialTheme.colorScheme.tertiary
             },
-        )
-    }
-    OutlinedTextField(
-        value = outputText,
-        onValueChange = onValueChange,
-        keyboardActions = KeyboardActions { focusManager.clearFocus() },
-        textStyle = MaterialTheme.typography.titleMedium,
-        colors = TextFieldDefaults.outlinedTextFieldColors(
-            textColor = MaterialTheme.colorScheme.tertiary,
             unfocusedBorderColor = MaterialTheme.colorScheme.surface,
             focusedBorderColor = MaterialTheme.colorScheme.surface,
         ),
         placeholder = {
             Text(
-                text = stringResource(id = R.string.output_hint),
+                text = if (isBefore) {
+                    stringResource(id = R.string.input_hint)
+                } else {
+                    stringResource(id = R.string.output_hint)
+                },
                 style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.tertiary,
+                color = if (isBefore) {
+                    MaterialTheme.colorScheme.secondary
+                } else {
+                    MaterialTheme.colorScheme.tertiary
+                },
             )
         },
         modifier = Modifier

--- a/app/src/main/java/ksnd/open/hiraganaconverter/view/screen/ConverterScreen.kt
+++ b/app/src/main/java/ksnd/open/hiraganaconverter/view/screen/ConverterScreen.kt
@@ -49,6 +49,7 @@ import ksnd.open.hiraganaconverter.view.parts.button.CustomFilledTonalIconButton
 import ksnd.open.hiraganaconverter.view.parts.button.MoveTopButton
 import ksnd.open.hiraganaconverter.view.parts.card.ConversionTypeSpinnerCard
 import ksnd.open.hiraganaconverter.view.parts.card.ErrorCard
+import ksnd.open.hiraganaconverter.view.theme.HiraganaConverterTheme
 import ksnd.open.hiraganaconverter.viewmodel.ConvertViewModel
 import ksnd.open.hiraganaconverter.viewmodel.ConvertViewModelImpl
 import ksnd.open.hiraganaconverter.viewmodel.PreviewConvertViewModel
@@ -131,7 +132,7 @@ private fun ConverterScreenContent(viewModel: ConvertViewModel) {
             Divider(
                 thickness = 2.dp,
                 color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(vertical = 8.dp, horizontal = 50.dp),
+                modifier = Modifier.padding(vertical = 8.dp, horizontal = 48.dp),
             )
 
             BeforeOrAfterTextField(
@@ -164,7 +165,9 @@ private fun BeforeOrAfterTextField(
                 String.format("[ %s ]", stringResource(id = R.string.after_conversion))
             },
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(all = 16.dp).weight(1f),
+            modifier = Modifier
+                .padding(all = 16.dp)
+                .weight(1f),
             color = MaterialTheme.colorScheme.onSurface,
         )
 
@@ -217,8 +220,20 @@ private fun BeforeOrAfterTextField(
 
 @Preview
 @Composable
-private fun PreviewConverterScreenContent() {
-    ConverterScreenContent(
-        viewModel = PreviewConvertViewModel(),
-    )
+private fun PreviewConverterScreenContent_Light() {
+    HiraganaConverterTheme(isDarkTheme = false) {
+        ConverterScreenContent(
+            viewModel = PreviewConvertViewModel(),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewConverterScreenContent_Dark() {
+    HiraganaConverterTheme(isDarkTheme = true) {
+        ConverterScreenContent(
+            viewModel = PreviewConvertViewModel(),
+        )
+    }
 }


### PR DESCRIPTION
- #44 のプルリクエスト
### 変更点
- プレビューの大量追加
- 変換画面の変換前と変換後のテキストフィールドを結合
- 変換が失敗したときに出るErrorCardを別パッケージに移動