### PR TITLE
変換画面のEdge to edgeに対応する

### DIFF
--- a/app/src/main/java/ksnd/hiraganaconverter/view/LocalIsDark.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/LocalIsDark.kt
@@ -1,0 +1,5 @@
+package ksnd.hiraganaconverter.view
+
+import androidx.compose.runtime.compositionLocalOf
+
+val LocalIsDark = compositionLocalOf { false }

--- a/app/src/main/java/ksnd/hiraganaconverter/view/MainActivity.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/MainActivity.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -53,15 +53,21 @@ class MainActivity : ComponentActivity() {
             val customFont: State<String> =
                 mainViewModel.customFont.collectAsState(initial = CustomFont.DEFAULT.name)
 
-            HiraganaConverterTheme(
-                isDarkTheme = when (themeNum.value) {
-                    ThemeNum.NIGHT.num -> true
-                    ThemeNum.DAY.num -> false
-                    else -> isSystemInDarkTheme()
-                },
-                customFont = customFont.value,
+            val isDarkTheme = when (themeNum.value) {
+                ThemeNum.NIGHT.num -> true
+                ThemeNum.DAY.num -> false
+                else -> isSystemInDarkTheme()
+            }
+
+            CompositionLocalProvider(
+                LocalIsDark provides isDarkTheme,
             ) {
-                ConverterScreen()
+                HiraganaConverterTheme(
+                    isDarkTheme = isDarkTheme,
+                    customFont = customFont.value,
+                ) {
+                    ConverterScreen()
+                }
             }
         }
     }

--- a/app/src/main/java/ksnd/hiraganaconverter/view/MainActivity.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/MainActivity.kt
@@ -5,12 +5,14 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -40,6 +42,8 @@ class MainActivity : ComponentActivity() {
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         }
+
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         setContent {
             val mainViewModel: MainViewModel = hiltViewModel()

--- a/app/src/main/java/ksnd/hiraganaconverter/view/parts/TopBar.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/parts/TopBar.kt
@@ -1,5 +1,8 @@
 package ksnd.hiraganaconverter.view.parts
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -9,8 +12,10 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -25,7 +30,10 @@ import ksnd.hiraganaconverter.view.parts.button.CustomIconButton
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TopBar(scrollBehavior: TopAppBarScrollBehavior) {
+fun TopBar(
+    modifier: Modifier = Modifier,
+    scrollBehavior: TopAppBarScrollBehavior,
+) {
     var isShowSettingDialog by rememberSaveable { mutableStateOf(false) }
     var isShowInfoDialog by rememberSaveable { mutableStateOf(false) }
     var isShowConvertHistoryDialog by rememberSaveable { mutableStateOf(false) }
@@ -46,41 +54,54 @@ fun TopBar(scrollBehavior: TopAppBarScrollBehavior) {
         )
     }
 
-    TopAppBar(
-        title = {},
-        colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-            containerColor = MaterialTheme.colorScheme.surface,
-            scrolledContainerColor = MaterialTheme.colorScheme.surface,
-            titleContentColor = MaterialTheme.colorScheme.primary,
-        ),
-        actions = {
-            CustomIconButton(
-                modifier = Modifier.padding(horizontal = 8.dp),
-                contentDescription = "info",
-                painter = painterResource(id = R.drawable.ic_outline_info_24),
-                onClick = { isShowInfoDialog = true },
-            )
-            CustomIconButton(
-                modifier = Modifier.padding(end = 8.dp),
-                contentDescription = "settings",
-                painter = painterResource(id = R.drawable.ic_outline_settings_24),
-                onClick = { isShowSettingDialog = true },
-            )
-            CustomIconButton(
-                contentDescription = "history",
-                painter = painterResource(id = R.drawable.ic_baseline_history_24),
-                onClick = { isShowConvertHistoryDialog = true },
-            )
-            Spacer(modifier = Modifier.weight(1f))
-            GooCreditImage()
-        },
-        scrollBehavior = scrollBehavior,
-    )
+    val isShowTopBar by remember(scrollBehavior.state.collapsedFraction) {
+        derivedStateOf { scrollBehavior.state.collapsedFraction != 1.toFloat() }
+    }
+
+    AnimatedVisibility(
+        visible = isShowTopBar,
+        modifier = modifier,
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        TopAppBar(
+            title = {},
+            colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+                scrolledContainerColor = MaterialTheme.colorScheme.surface,
+                titleContentColor = MaterialTheme.colorScheme.primary,
+            ),
+            actions = {
+                CustomIconButton(
+                    modifier = Modifier.padding(horizontal = 8.dp),
+                    contentDescription = "info",
+                    painter = painterResource(id = R.drawable.ic_outline_info_24),
+                    onClick = { isShowInfoDialog = true },
+                )
+                CustomIconButton(
+                    modifier = Modifier.padding(end = 8.dp),
+                    contentDescription = "settings",
+                    painter = painterResource(id = R.drawable.ic_outline_settings_24),
+                    onClick = { isShowSettingDialog = true },
+                )
+                CustomIconButton(
+                    contentDescription = "history",
+                    painter = painterResource(id = R.drawable.ic_baseline_history_24),
+                    onClick = { isShowConvertHistoryDialog = true },
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                GooCreditImage()
+            },
+            scrollBehavior = scrollBehavior,
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
 private fun PreviewTopBar() {
-    TopBar(TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState()))
+    TopBar(
+        scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState()),
+    )
 }


### PR DESCRIPTION
## Issue
fix #91 

## Overview
- ScaffoldのinnerPaddingを`consumeWindowInsets()`で使用しないようにした
- SystembarsのdarkIconsをモードによって切り替えたいために`LocalIsDark`という値を用意し、CompositionLocalProviderで渡すようにした
- TopBarは、状況によってAnimatedVisibilityで表示をアニメーションさせるようにした

## Reference
-

## Screenshot
|Before|After|
|---|---|
|<video src="https://github.com/kosenda/hiragana-converter/assets/60963155/18de0109-0e6a-4249-8940-51aa8af1983c">|<video src="https://github.com/kosenda/hiragana-converter/assets/60963155/3cd45475-f572-4850-89cf-690b1de7a0f7">|
