### PR TITLE
スクロール時に表示されるフローティングボタンのデザイン変更 

### DIFF
--- a/app/src/main/java/ksnd/hiraganaconverter/view/parts/button/MoveTopButton.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/parts/button/MoveTopButton.kt
@@ -5,9 +5,11 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideIn
 import androidx.compose.animation.slideOut
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
@@ -19,6 +21,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
@@ -46,12 +50,13 @@ fun MoveTopButton(scrollState: ScrollState) {
                     scrollState.animateScrollTo(0)
                 }
             },
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
         ) {
-            Text(
-                modifier = Modifier.padding(vertical = 4.dp, horizontal = 16.dp),
-                text = stringResource(id = R.string.top),
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                style = MaterialTheme.typography.bodyLarge,
+            Image(
+                painter = painterResource(id = R.drawable.baseline_keyboard_arrow_up_24),
+                contentDescription = stringResource(id = R.string.top),
+                modifier = Modifier.size(48.dp),
+                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSecondaryContainer),
             )
         }
     }

--- a/app/src/main/res/drawable/baseline_keyboard_arrow_up_24.xml
+++ b/app/src/main/res/drawable/baseline_keyboard_arrow_up_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M7.41,15.41L12,10.83l4.59,4.58L18,14l-6,-6 -6,6z"/>
+</vector>


### PR DESCRIPTION
## Issue
fix #94 

## Overview
- Topからハットみたいなアイコンにした


## Screenshot
|Before|After|
|---|---|
|<img src="https://github.com/kosenda/hiragana-converter/assets/60963155/52135f9d-0d74-4ad1-b9c3-93889b7a1c3a" width="350">|<img src="https://github.com/kosenda/hiragana-converter/assets/60963155/c4c978fa-51bb-4249-a3af-a6e6fb405402" width="350">|
