### PR TITLE
hot-fix API通信に失敗する

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "ksnd.hiraganaconverter"
         minSdk = 24
         targetSdk = 33
-        versionCode = 30
-        versionName = "1.19"
+        versionCode = 31
+        versionName = "1.20"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -34,7 +34,10 @@
 # CallとResponseのジェネリックのシグネチャを保持する
 -keep,allowobfuscation,allowshrinking interface retrofit2.Call
 -keep,allowobfuscation,allowshrinking class retrofit2.Response
-
+# With R8 full mode generic signatures are stripped for classes that are not
+# kept. Suspend functions are wrapped in continuations where the type argument
+# is used.
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
 
 # ■ kotlinx.serializationの設定 ---------------------------------------------------------------------
 
@@ -49,7 +52,6 @@
     kotlinx.serialization.KSerializer serializer(...);
 }
 # アプリ固有のもの
-# Change here com.yourcompany.yourpackage
 -keepclassmembers @kotlinx.serialization.Serializable class ksnd.hiraganaconverter.model.** {
     # lookup for plugin generated serializable classes
     *** Companion;


### PR DESCRIPTION
## Overview
- proguardの設定（retrofit）が足りてなくて起きた事象
- バージョンも1.20に上げる
