### PR TITLE
OSSライセンスの詳細を開こうとするとクラッシュすることがある

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,10 @@
             </intent-filter>
         </activity>
         <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
+            android:theme="@style/Theme.AppCompat.Light.DarkActionBar">
+        </activity>
+        <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
             android:theme="@style/Theme.AppCompat.Light.DarkActionBar">
         </activity>


### PR DESCRIPTION
## Issue
fix #140 

## Overview
- OssLicensesActivityをmanifestに設定してなくて落ちていた
- エミュレータ（Pixel5 API27）でクラッシュしなくなったことを確認ずみ