### PR TITLE
[ デザイン変更 ]ConvertHistoryDetailDialogの見た目が他のダイアログと違って上側の隙間がない 

### DIFF
--- a/app/src/main/java/ksnd/hiraganaconverter/view/dialog/ConvertHistoryDetailDialog.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/dialog/ConvertHistoryDetailDialog.kt
@@ -63,13 +63,16 @@ private fun ConvertHistoryDetailDialogContent(
 
     Surface(
         modifier = Modifier
-            .fillMaxHeight(0.90f)
-            .fillMaxWidth(0.90f)
+            .fillMaxHeight(0.95f)
+            .fillMaxWidth(0.95f)
             .border(width = 4.dp, color = MaterialTheme.colorScheme.surfaceVariant, shape = RoundedCornerShape(16.dp))
             .clip(RoundedCornerShape(16.dp)),
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
             DialogCloseButton(
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 16.dp),
                 leftContent = {
                     Text(
                         text = historyData.time,


### PR DESCRIPTION
## Issue
fix #147 

## Overview
- ダイアログのサイズを画面の比率の0.9倍から0.95倍にした
- ばつボタンに他のダイアログと同様の余白をつけた

## Screenshot
|Before|After|
|---|---|
|<img src="https://github.com/kosenda/hiragana-converter/assets/60963155/bc861b49-f798-4ad3-afb9-7d45ef3daa84" width="350">|<img src="https://github.com/kosenda/hiragana-converter/assets/60963155/048d6a14-27b7-4143-9290-c7be62b63326" width="350">|
