### PR TITLE
変換時にクラッシュすることがある（java.lang.IllegalStateException - Not defined ConvertErrorType!

### DIFF
--- a/app/src/main/java/ksnd/hiraganaconverter/viewmodel/ConvertViewModelImpl.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/viewmodel/ConvertViewModelImpl.kt
@@ -57,7 +57,10 @@ class ConvertViewModelImpl @Inject constructor(
                                 ConvertErrorType.CONVERSION_FAILED.name -> ConvertErrorType.CONVERSION_FAILED
                                 ConvertErrorType.INTERNAL_SERVER.name -> ConvertErrorType.INTERNAL_SERVER
                                 ConvertErrorType.NETWORK.name -> ConvertErrorType.NETWORK
-                                else -> throw IllegalStateException("Not defined ConvertErrorType!")
+                                else -> {
+                                    Timber.w("InterceptorError: %s".format(throwable.message))
+                                    ConvertErrorType.CONVERSION_FAILED
+                                }
                             }
                             else -> throw IllegalStateException("Not defined ConvertTextUseCaseException!")
                         },


### PR DESCRIPTION
## Issue
fix #156 

## Overview
- 設定していないメッセージの時はエラーをthrowしないようにした
