### PR TITLE
アプリごとの言語設定の見直し

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,6 +23,11 @@ android {
     namespace = "ksnd.hiraganaconverter"
     compileSdk = 34
 
+    androidResources {
+        @Suppress("UnstableApiUsage")
+        generateLocaleConfig = true
+    }
+
     defaultConfig {
         applicationId = "ksnd.hiraganaconverter"
         minSdk = 26
@@ -61,6 +66,7 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+    @Suppress("UnstableApiUsage")
     testOptions {
         unitTests.isIncludeAndroidResources = true
         unitTests.isReturnDefaultValues = true
@@ -101,6 +107,7 @@ dependencies {
     implementation(libs.androidx.dataStore.preferences)
 
     // ktlint
+    @Suppress("UnstableApiUsage")
     ktlint(libs.ktlint) {
         attributes {
             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,15 @@
             android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
             android:theme="@style/Theme.AppCompat.Light.DarkActionBar">
         </activity>
+
+        <!--Per-app language preferences Support Android 12 and lower -->
+        <service android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
+            android:enabled="false"
+            android:exported="false">
+            <meta-data
+                android:name="autoStoreLocales"
+                android:value="true" />
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/res/resources.properties
+++ b/app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en-US

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
-    <locale android:name="en"/>
-    <locale android:name="ja"/>
-</locale-config>


### PR DESCRIPTION
## Issue
fix #177 

## Overview
- アプリごとの言語設定していたと思っていたができていなかったのと自動設定が新しく入ってきたため確認して修正した
- 別アプリ（１３言語対応）でリリースビルドかつ内部アプリ共有でAndroid14とAndroid9で確認したが、言語設定をOSの設定から切り替えれたり、アプリキルした後に再度開くと言語が設定されていることを確認した

## Reference
- [Android developers - Per-app language preferences](https://developer.android.com/guide/topics/resources/app-languages#app-language-settings)
アプリごとの言語設定で参照（日本語はまだ対応していない）
- [Android 14 新機能 / Android 14 Meetup Nagoya](https://speakerdeck.com/star_zero/android-14-meetup-nagoya?slide=6)
localeのファイルがどこに生成されるか確認
