### PR TITLE
AccompanistのSystemUiControllerを使用しないようにする

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -169,7 +169,7 @@ tasks.create<JavaExec>("ktlintCheck") {
     mainClass.set("com.pinterest.ktlint.Main")
     args = listOf(
         "src/**/*.kt",
-        "--reporter=checkstyle,output${layout.buildDirectory.get()}/reports/ktlint/ktlint-result.xml",
+        "--reporter=checkstyle,output=${layout.buildDirectory.get()}/reports/ktlint/ktlint-result.xml",
     )
     isIgnoreExitValue = true
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,13 +73,13 @@ android {
 }
 
 dependencies {
+    implementation(libs.androidx.activity)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)
     implementation(libs.junit)
     testImplementation(libs.kotlin.test)
 
     // Accompanist
-    implementation(libs.accompanist.systemuicontroller)
     implementation(libs.accompanist.webView)
 
     // Compose
@@ -169,7 +169,7 @@ tasks.create<JavaExec>("ktlintCheck") {
     mainClass.set("com.pinterest.ktlint.Main")
     args = listOf(
         "src/**/*.kt",
-        "--reporter=checkstyle,output=${buildDir}/reports/ktlint/ktlint-result.xml",
+        "--reporter=checkstyle,output${layout.buildDirectory.get()}/reports/ktlint/ktlint-result.xml",
     )
     isIgnoreExitValue = true
 }
@@ -200,10 +200,10 @@ tasks.create<JacocoReport>("jacocoTestReport") {
     }
 
     gradle.afterProject {
-        executionData.setFrom(file("$buildDir/jacoco/$testTaskName.exec"))
+        executionData.setFrom(file("${layout.buildDirectory.get()}/jacoco/$testTaskName.exec"))
         sourceDirectories.setFrom(files("$projectDir/src/main/java", "$projectDir/src/main/kotlin"))
         classDirectories.setFrom(
-            fileTree("$buildDir/tmp/kotlin-classes/debug") {
+            fileTree("${layout.buildDirectory.get()}/tmp/kotlin-classes/debug") {
                 exclude(
                     "**/R.class",
                     "**/R\$*.class",

--- a/app/src/main/java/ksnd/hiraganaconverter/view/LocalIsDark.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/LocalIsDark.kt
@@ -1,5 +1,0 @@
-package ksnd.hiraganaconverter.view
-
-import androidx.compose.runtime.compositionLocalOf
-
-val LocalIsDark = compositionLocalOf { false }

--- a/app/src/main/java/ksnd/hiraganaconverter/view/MainActivity.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/MainActivity.kt
@@ -94,7 +94,7 @@ class MainActivity : AppCompatActivity() {
                         detectDarkMode = { isDarkTheme },
                     ),
                 )
-                onDispose {  }
+                onDispose { }
             }
 
             LaunchedEffect(inAppUpdateState) {

--- a/app/src/main/java/ksnd/hiraganaconverter/view/MainActivity.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/MainActivity.kt
@@ -1,7 +1,9 @@
 package ksnd.hiraganaconverter.view
 
 import android.os.Bundle
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -12,7 +14,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
-import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -20,8 +22,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -64,7 +67,7 @@ class MainActivity : AppCompatActivity() {
 
         super.onCreate(savedInstanceState)
 
-        WindowCompat.setDecorFitsSystemWindows(window, false)
+        enableEdgeToEdge()
 
         setContent {
             val theme by mainViewModel.theme.collectAsState(initial = Theme.AUTO)
@@ -76,6 +79,22 @@ class MainActivity : AppCompatActivity() {
                 Theme.NIGHT -> true
                 Theme.DAY -> false
                 else -> isSystemInDarkTheme()
+            }
+
+            DisposableEffect(isDarkTheme) {
+                enableEdgeToEdge(
+                    statusBarStyle = SystemBarStyle.auto(
+                        lightScrim = Color.Transparent.toArgb(),
+                        darkScrim = Color.Transparent.toArgb(),
+                        detectDarkMode = { isDarkTheme },
+                    ),
+                    navigationBarStyle = SystemBarStyle.auto(
+                        lightScrim = Color.Transparent.toArgb(),
+                        darkScrim = Color.Transparent.toArgb(),
+                        detectDarkMode = { isDarkTheme },
+                    ),
+                )
+                onDispose {  }
             }
 
             LaunchedEffect(inAppUpdateState) {
@@ -95,31 +114,27 @@ class MainActivity : AppCompatActivity() {
                 }
             }
 
-            CompositionLocalProvider(
-                LocalIsDark provides isDarkTheme,
+            HiraganaConverterTheme(
+                isDarkTheme = isDarkTheme,
+                fontType = fontType,
             ) {
-                HiraganaConverterTheme(
-                    isDarkTheme = isDarkTheme,
-                    fontType = fontType,
-                ) {
-                    // Because the state changes before the animation ends
-                    val downloadPercentage = if (inAppUpdateState is InAppUpdateState.Downloading) {
-                        (inAppUpdateState as InAppUpdateState.Downloading).percentage
-                    } else {
-                        100
-                    }
+                // Because the state changes before the animation ends
+                val downloadPercentage = if (inAppUpdateState is InAppUpdateState.Downloading) {
+                    (inAppUpdateState as InAppUpdateState.Downloading).percentage
+                } else {
+                    100
+                }
 
-                    Column {
-                        InAppUpdateDownloadingContent(
-                            text = this@MainActivity.getString(R.string.in_app_update_downloading_snackbar_title, downloadPercentage),
-                            isVisible = inAppUpdateState is InAppUpdateState.Downloading,
-                        )
-                        ConverterScreen(
-                            modifier = Modifier.weight(1f),
-                            snackbarHostState = snackbarHostState,
-                            convertViewModel = hiltViewModel(),
-                        )
-                    }
+                Column {
+                    InAppUpdateDownloadingContent(
+                        text = this@MainActivity.getString(R.string.in_app_update_downloading_snackbar_title, downloadPercentage),
+                        isVisible = inAppUpdateState is InAppUpdateState.Downloading,
+                    )
+                    ConverterScreen(
+                        modifier = Modifier.weight(1f),
+                        snackbarHostState = snackbarHostState,
+                        convertViewModel = hiltViewModel(),
+                    )
                 }
             }
         }

--- a/app/src/main/java/ksnd/hiraganaconverter/view/screen/ConverterScreen.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/screen/ConverterScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -58,11 +57,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import ksnd.hiraganaconverter.R
 import ksnd.hiraganaconverter.model.ConvertErrorType
 import ksnd.hiraganaconverter.model.repository.LIMIT_CONVERT_COUNT
-import ksnd.hiraganaconverter.view.LocalIsDark
 import ksnd.hiraganaconverter.view.parts.TopBar
 import ksnd.hiraganaconverter.view.parts.button.ConvertButton
 import ksnd.hiraganaconverter.view.parts.button.CustomButtonWithBackground
@@ -82,13 +79,6 @@ fun ConverterScreen(
     snackbarHostState: SnackbarHostState,
     convertViewModel: ConvertViewModelImpl,
 ) {
-    val systemUiController = rememberSystemUiController()
-    val isDarkTheme = LocalIsDark.current
-
-    SideEffect {
-        systemUiController.setSystemBarsColor(color = Color.Transparent, darkIcons = isDarkTheme.not())
-    }
-
     ConverterScreenContent(
         modifier = modifier,
         viewModel = convertViewModel,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 accompanist = "0.32.0"
+activity = "1.8.0-alpha07"
 androidGradlePlugin = "8.1.1"
 androidxAppCompat = "1.7.0-alpha03"
 androidxComposeMaterial3 = "1.2.0-alpha06"
@@ -41,10 +42,10 @@ jacoco = "0.8.9"
 
 [libraries]
 # Accompanist
-accompanist-systemuicontroller = { group = "com.google.accompanist", name = "accompanist-systemuicontroller", version.ref = "accompanist" }
 accompanist-webView = { group = "com.google.accompanist", name = "accompanist-webview", version.ref = "accompanist" }
 
 # Androidx
+androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "androidxComposeMaterial3" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "androidxUi" }


### PR DESCRIPTION
## Issue
fix #194 

## Overview
- AccompanistのSystemUiControllerを取り除いた
- 代わりのActivityの`EdgeToEdge.enableEdgeToEdge`を使用するようにした
- NowInAndroidが参考になった（リンクは、プルリクだと迷惑かけそうだからXを経由させる）
- `SystemBarStyle.auto`の`detectDarkMode`はドキュメント見ると不要そうに見えたが、設定しないとアイコンと背景が同色になってしまったため必要

## Reference
- [NowInAndroid](https://twitter.com/ksnd_dev/status/1697859967183896710?s=20)
- [accompanist - systemuicontroller](https://google.github.io/accompanist/systemuicontroller/)
- [Android developers - EdgeToEdge.enableEdgeToEdge](https://developer.android.com/reference/androidx/activity/ComponentActivity#(androidx.activity.ComponentActivity).enableEdgeToEdge(androidx.activity.SystemBarStyle,androidx.activity.SystemBarStyle))

## Screenshot
|Before|After|
|---|---|
|<img src="" width="350">|<img src="" width="350">|
|<video src="https://github.com/kosenda/hiragana-converter/assets/60963155/d15ec6d4-aeda-496b-80ef-e0d20e91cfd1">|<video src="https://github.com/kosenda/hiragana-converter/assets/60963155/2231371f-5955-4137-ad9f-ac795986d34f">|
