### PR TITLE
一部のボタンにHapticsをつける

### DIFF
--- a/app/src/main/java/ksnd/hiraganaconverter/view/extension/NoRippleClickable.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/extension/NoRippleClickable.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.semantics.Role
 
 inline fun Modifier.noRippleClickable(

--- a/app/src/main/java/ksnd/hiraganaconverter/view/parts/button/CustomButtonWithBackground.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/parts/button/CustomButtonWithBackground.kt
@@ -1,5 +1,6 @@
 package ksnd.hiraganaconverter.view.parts.button
 
+import android.view.HapticFeedbackConstants.CONTEXT_CLICK
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -14,6 +15,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -32,12 +34,16 @@ fun CustomButtonWithBackground(
     onClick: () -> Unit,
 ) {
     val buttonScaleState = rememberButtonScaleState()
+    val localView = LocalView.current
     IconButton(
         modifier = modifier
             .padding(all = 8.dp)
             .size(size = 56.dp)
             .scale(scale = buttonScaleState.animationScale.value),
-        onClick = onClick,
+        onClick = {
+            localView.performHapticFeedback(CONTEXT_CLICK)
+            onClick()
+        },
         colors = IconButtonDefaults.iconButtonColors(containerColor = containerColor),
         interactionSource = buttonScaleState.interactionSource,
     ) {

--- a/app/src/main/java/ksnd/hiraganaconverter/view/parts/card/ConversionTypeCard.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/parts/card/ConversionTypeCard.kt
@@ -1,5 +1,6 @@
 package ksnd.hiraganaconverter.view.parts.card
 
+import android.view.HapticFeedbackConstants
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -14,6 +15,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -30,6 +32,7 @@ fun ConversionTypeCard(
 ) {
     var selectedTextType by rememberSaveable { mutableStateOf(HiraKanaType.HIRAGANA) }
     val buttonScaleState = rememberButtonScaleState()
+    val localView = LocalView.current
 
     Card(
         modifier = Modifier
@@ -38,6 +41,7 @@ fun ConversionTypeCard(
             .noRippleClickable(
                 interactionSource = buttonScaleState.interactionSource,
                 onClick = {
+                    localView.performHapticFeedback(HapticFeedbackConstants.CONTEXT_CLICK)
                     selectedTextType = when (selectedTextType) {
                         HiraKanaType.HIRAGANA -> HiraKanaType.KATAKANA
                         HiraKanaType.KATAKANA -> HiraKanaType.HIRAGANA


### PR DESCRIPTION
## Issue
fix #199 

## Overview
- 変換ボタン、テキストの削除ボタン、変換タイプ変換ボタンの３つにHapticsをつけた

## Reference
### [Android developers - CONTEXT_CLICK](https://developer.android.com/reference/android/view/HapticFeedbackConstants#CONTEXT_CLICK)
- API23以上で、ちょうどいいくらいの強さだと思ったからこれにした
### [GitHub - platforms sample  Haptic Samples](https://github.com/android/platform-samples/tree/main/samples/user-interface/haptics)
- 実装例を参考にした
