### PR TITLE
【リファクタ】命名がおかしい-1

### DIFF
--- a/app/src/main/java/ksnd/hiraganaconverter/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/viewmodel/MainActivityViewModel.kt
@@ -31,8 +31,8 @@ class MainActivityViewModel @Inject constructor(
     val inAppUpdateState: Flow<InAppUpdateState> = _inAppUpdateState.asStateFlow()
 
     val uiState = combine(
-        dataStoreRepository.selectedTheme(),
-        dataStoreRepository.selectedFontType(),
+        dataStoreRepository.theme(),
+        dataStoreRepository.fontType(),
     ) { theme, fontType ->
         MainActivityUiState(
             theme = theme,

--- a/app/src/test/java/ksnd/hiraganaconverter/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/ksnd/hiraganaconverter/viewmodel/MainActivityViewModelTest.kt
@@ -54,16 +54,16 @@ class MainActivityViewModelTest {
             dataStoreRepository.emit(nextFontType)
             assertThat(awaitItem().fontType).isEqualTo(nextFontType)
         }
-        verify(exactly = 1) { dataStoreRepository.selectedTheme() }
-        verify(exactly = 1) { dataStoreRepository.selectedFontType() }
+        verify(exactly = 1) { dataStoreRepository.theme() }
+        verify(exactly = 1) { dataStoreRepository.fontType() }
     }
 
     companion object {
         class FakeDataStoreRepository : DataStoreRepository {
             private val theme = MutableStateFlow(MainActivityUiState().theme)
             private val fontType = MutableStateFlow(MainActivityUiState().fontType)
-            override fun selectedTheme(): Flow<Theme> = theme
-            override fun selectedFontType(): Flow<FontType> = fontType
+            override fun theme(): Flow<Theme> = theme
+            override fun fontType(): Flow<FontType> = fontType
             override fun enableInAppUpdate(): Flow<Boolean> = flowOf(false)
             override suspend fun updateTheme(newTheme: Theme) {}
             override suspend fun updateFontType(fontType: FontType) {}

--- a/core/data/src/main/java/ksnd/hiraganaconverter/data/database/ConvertHistoryDao.kt
+++ b/core/data/src/main/java/ksnd/hiraganaconverter/data/database/ConvertHistoryDao.kt
@@ -15,7 +15,7 @@ interface ConvertHistoryDao {
 
     // ■ READ
     @Query("select * from convert_history")
-    fun getAllConvertHistory(): Flow<List<ConvertHistoryData>>
+    fun observeAllConvertHistory(): Flow<List<ConvertHistoryData>>
 
     // ■ DELETE
     @Query("delete from convert_history")

--- a/core/data/src/main/java/ksnd/hiraganaconverter/data/repository/ConvertHistoryRepositoryImpl.kt
+++ b/core/data/src/main/java/ksnd/hiraganaconverter/data/repository/ConvertHistoryRepositoryImpl.kt
@@ -22,8 +22,8 @@ class ConvertHistoryRepositoryImpl @Inject constructor(
         )
     }
 
-    override fun getAllConvertHistory(): Flow<List<ConvertHistoryData>> =
-        convertHistoryDao.getAllConvertHistory()
+    override fun observeAllConvertHistory(): Flow<List<ConvertHistoryData>> =
+        convertHistoryDao.observeAllConvertHistory()
 
     override fun deleteAllConvertHistory() =
         convertHistoryDao.deleteAllConvertHistory()

--- a/core/data/src/main/java/ksnd/hiraganaconverter/data/repository/DataStoreRepositoryImpl.kt
+++ b/core/data/src/main/java/ksnd/hiraganaconverter/data/repository/DataStoreRepositoryImpl.kt
@@ -25,7 +25,7 @@ class DataStoreRepositoryImpl @Inject constructor(
     private val dataStore: DataStore<Preferences>,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : DataStoreRepository {
-    override fun selectedTheme(): Flow<Theme> {
+    override fun theme(): Flow<Theme> {
         return dataStore.data
             .catch { exception ->
                 Timber.e("DataStore: %s", exception)
@@ -36,7 +36,7 @@ class DataStoreRepositoryImpl @Inject constructor(
             }
     }
 
-    override fun selectedFontType(): Flow<FontType> {
+    override fun fontType(): Flow<FontType> {
         return dataStore.data
             .catch { exception ->
                 Timber.e("DataStore: %s", exception)

--- a/core/data/src/test/java/ksnd/hiraganaconverter/data/repository/ConvertHistoryRepositoryImplTest.kt
+++ b/core/data/src/test/java/ksnd/hiraganaconverter/data/repository/ConvertHistoryRepositoryImplTest.kt
@@ -30,22 +30,22 @@ class ConvertHistoryRepositoryImplTest {
     private val convertHistoryRepositoryImpl = ConvertHistoryRepositoryImpl(convertHistoryDao = convertHistoryDao)
 
     @Test
-    fun getAllConvertHistory_initial_isEmpty() = runTest {
-        assertThat(convertHistoryRepositoryImpl.getAllConvertHistory().firstOrNull()).isEmpty()
-        verify(exactly = 1) { convertHistoryDao.getAllConvertHistory() }
+    fun observeAllConvertHistory_initial_isEmpty() = runTest {
+        assertThat(convertHistoryRepositoryImpl.observeAllConvertHistory().firstOrNull()).isEmpty()
+        verify(exactly = 1) { convertHistoryDao.observeAllConvertHistory() }
     }
 
     @Test
     fun insertConvertHistory_addHistoryOnce_size1() = runTest {
         convertHistoryRepositoryImpl.insertConvertHistory(beforeText = BEFORE_TEXT, afterText = AFTER_TEXT)
-        assertThat(convertHistoryRepositoryImpl.getAllConvertHistory().first().size).isEqualTo(1)
+        assertThat(convertHistoryRepositoryImpl.observeAllConvertHistory().first().size).isEqualTo(1)
         verify(exactly = 1) { convertHistoryDao.insertConvertHistory(any()) }
     }
 
     @Test
     fun insertConvertHistory_add3Histories_size3() = runTest {
         repeat(3) { convertHistoryRepositoryImpl.insertConvertHistory(beforeText = BEFORE_TEXT, afterText = AFTER_TEXT) }
-        assertThat(convertHistoryRepositoryImpl.getAllConvertHistory().first().size).isEqualTo(3)
+        assertThat(convertHistoryRepositoryImpl.observeAllConvertHistory().first().size).isEqualTo(3)
         verify(exactly = 3) { convertHistoryDao.insertConvertHistory(any()) }
     }
 
@@ -53,17 +53,17 @@ class ConvertHistoryRepositoryImplTest {
     fun deleteAllConvertHistory_exist3Histories_isEmpty() = runTest {
         repeat(3) { convertHistoryRepositoryImpl.insertConvertHistory(beforeText = BEFORE_TEXT, afterText = AFTER_TEXT) }
         convertHistoryRepositoryImpl.deleteAllConvertHistory()
-        assertThat(convertHistoryRepositoryImpl.getAllConvertHistory().firstOrNull()).isEmpty()
+        assertThat(convertHistoryRepositoryImpl.observeAllConvertHistory().firstOrNull()).isEmpty()
         verify(exactly = 1) { convertHistoryDao.deleteAllConvertHistory() }
     }
 
     @Test
     fun convertHistoryRepository_deleteOnce_sizeMinus1() = runTest {
         repeat(3) { convertHistoryRepositoryImpl.insertConvertHistory(beforeText = BEFORE_TEXT, afterText = AFTER_TEXT) }
-        assertThat(convertHistoryRepositoryImpl.getAllConvertHistory().first().size).isEqualTo(3)
-        val deleteHistoryId = convertHistoryRepositoryImpl.getAllConvertHistory().first().first().id
+        assertThat(convertHistoryRepositoryImpl.observeAllConvertHistory().first().size).isEqualTo(3)
+        val deleteHistoryId = convertHistoryRepositoryImpl.observeAllConvertHistory().first().first().id
         convertHistoryRepositoryImpl.deleteConvertHistory(id = deleteHistoryId)
-        assertThat(convertHistoryRepositoryImpl.getAllConvertHistory().first().size).isEqualTo(2)
+        assertThat(convertHistoryRepositoryImpl.observeAllConvertHistory().first().size).isEqualTo(2)
     }
 
     companion object {
@@ -84,7 +84,7 @@ private class FakeConvertHistoryDao : ConvertHistoryDao {
         convertHistoryDataList.add(changedIdConvertHistoryData)
     }
 
-    override fun getAllConvertHistory(): Flow<List<ConvertHistoryData>> {
+    override fun observeAllConvertHistory(): Flow<List<ConvertHistoryData>> {
         return flowOf(convertHistoryDataList)
     }
 

--- a/core/data/src/test/java/ksnd/hiraganaconverter/data/repository/DataStoreRepositoryImplTest.kt
+++ b/core/data/src/test/java/ksnd/hiraganaconverter/data/repository/DataStoreRepositoryImplTest.kt
@@ -31,13 +31,13 @@ class DataStoreRepositoryImplTest {
     )
 
     @Test
-    fun selectedTheme_initial_isAutoNum() = runTest {
-        assertThat(dataStoreRepository.selectedTheme().first()).isEqualTo(Theme.AUTO)
+    fun theme_initial_isAutoNum() = runTest {
+        assertThat(dataStoreRepository.theme().first()).isEqualTo(Theme.AUTO)
     }
 
     @Test
-    fun selectedFontType_initial_isYuseiMagic() = runTest {
-        assertThat(dataStoreRepository.selectedFontType().first()).isEqualTo(FontType.YUSEI_MAGIC)
+    fun fontType_initial_isYuseiMagic() = runTest {
+        assertThat(dataStoreRepository.fontType().first()).isEqualTo(FontType.YUSEI_MAGIC)
     }
 
     @Test
@@ -48,17 +48,17 @@ class DataStoreRepositoryImplTest {
     @Test
     fun updateTheme_newTheme_isChangedTheme() = runTest {
         dataStoreRepository.updateTheme(Theme.DAY)
-        assertThat(dataStoreRepository.selectedTheme().first()).isEqualTo(Theme.DAY)
+        assertThat(dataStoreRepository.theme().first()).isEqualTo(Theme.DAY)
         dataStoreRepository.updateTheme(Theme.NIGHT)
-        assertThat(dataStoreRepository.selectedTheme().first()).isEqualTo(Theme.NIGHT)
+        assertThat(dataStoreRepository.theme().first()).isEqualTo(Theme.NIGHT)
     }
 
     @Test
     fun updateFontType_newFontType_isChangedFontType() = runTest {
         dataStoreRepository.updateFontType(FontType.ROCKN_ROLL_ONE)
-        assertThat(dataStoreRepository.selectedFontType().first()).isEqualTo(FontType.ROCKN_ROLL_ONE)
+        assertThat(dataStoreRepository.fontType().first()).isEqualTo(FontType.ROCKN_ROLL_ONE)
         dataStoreRepository.updateFontType(FontType.DEFAULT)
-        assertThat(dataStoreRepository.selectedFontType().first()).isEqualTo(FontType.DEFAULT)
+        assertThat(dataStoreRepository.fontType().first()).isEqualTo(FontType.DEFAULT)
     }
 
     @Test

--- a/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/repository/ConvertHistoryRepository.kt
+++ b/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/repository/ConvertHistoryRepository.kt
@@ -5,7 +5,7 @@ import ksnd.hiraganaconverter.core.model.ConvertHistoryData
 
 interface ConvertHistoryRepository {
     fun insertConvertHistory(beforeText: String, afterText: String)
-    fun getAllConvertHistory(): Flow<List<ConvertHistoryData>>
+    fun observeAllConvertHistory(): Flow<List<ConvertHistoryData>>
     fun deleteAllConvertHistory()
     fun deleteConvertHistory(id: Long)
 }

--- a/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/repository/DataStoreRepository.kt
+++ b/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/repository/DataStoreRepository.kt
@@ -5,8 +5,8 @@ import ksnd.hiraganaconverter.core.model.ui.FontType
 import ksnd.hiraganaconverter.core.model.ui.Theme
 
 interface DataStoreRepository {
-    fun selectedTheme(): Flow<Theme>
-    fun selectedFontType(): Flow<FontType>
+    fun theme(): Flow<Theme>
+    fun fontType(): Flow<FontType>
     fun enableInAppUpdate(): Flow<Boolean>
     suspend fun updateTheme(newTheme: Theme)
     suspend fun updateFontType(fontType: FontType)

--- a/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/ConvertHistoryViewModel.kt
+++ b/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/ConvertHistoryViewModel.kt
@@ -25,7 +25,7 @@ class ConvertHistoryViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            convertHistoryRepository.getAllConvertHistory().collect { convertHistories ->
+            convertHistoryRepository.observeAllConvertHistory().collect { convertHistories ->
                 _uiState.update { it.copy(convertHistories = convertHistories.sortedByDescending { data -> data.id }) }
             }
         }

--- a/feature/setting/src/main/java/ksnd/hiraganaconverter/feature/setting/SettingDialog.kt
+++ b/feature/setting/src/main/java/ksnd/hiraganaconverter/feature/setting/SettingDialog.kt
@@ -99,7 +99,7 @@ private fun SettingDialogContent(
             ) {
                 SettingThemeContent(
                     onRadioButtonClick = updateTheme,
-                    isSelectedTheme = uiState.theme,
+                    selectedTheme = uiState.theme,
                 )
                 SettingLanguageContent(
                     onClick = {
@@ -122,7 +122,7 @@ private fun SettingDialogContent(
 
 @Composable
 private fun SettingThemeContent(
-    isSelectedTheme: Theme,
+    selectedTheme: Theme,
     onRadioButtonClick: (Theme) -> Unit,
 ) {
     val modeRadioResourceTriple: List<Triple<Theme, String, Painter>> = listOf(
@@ -156,7 +156,7 @@ private fun SettingThemeContent(
         modeRadioResourceTriple.map { resource ->
             val (theme, displayThemeName, painter) = resource
             CustomRadioButton(
-                isSelected = theme == isSelectedTheme,
+                isSelected = theme == selectedTheme,
                 buttonText = displayThemeName,
                 painter = painter,
                 onClick = { onRadioButtonClick(theme) },

--- a/feature/setting/src/main/java/ksnd/hiraganaconverter/feature/setting/SettingsViewModel.kt
+++ b/feature/setting/src/main/java/ksnd/hiraganaconverter/feature/setting/SettingsViewModel.kt
@@ -22,8 +22,8 @@ class SettingsViewModel @Inject constructor(
 ) : ViewModel() {
 
     val uiState = combine(
-        dataStoreRepository.selectedTheme(),
-        dataStoreRepository.selectedFontType(),
+        dataStoreRepository.theme(),
+        dataStoreRepository.fontType(),
         dataStoreRepository.enableInAppUpdate(),
     ) { theme, fontType, enableInAppUpdate ->
         SettingsUiState(

--- a/feature/setting/src/test/java/ksnd/hiraganaconverter/feature/setting/SettingsViewModelTest.kt
+++ b/feature/setting/src/test/java/ksnd/hiraganaconverter/feature/setting/SettingsViewModelTest.kt
@@ -32,8 +32,8 @@ class SettingsViewModelTest {
         assertThat(FIRST_SAVED_FONT_TYPE).isNotEqualTo(SettingsUiState().fontType)
         assertThat(FIRST_SAVED_ENABLE_IN_APP_UPDATE).isNotEqualTo(SettingsUiState().enableInAppUpdate)
 
-        every { dataStoreRepository.selectedTheme() } returns flowOf(FIRST_SAVED_THEME)
-        every { dataStoreRepository.selectedFontType() } returns flowOf(FIRST_SAVED_FONT_TYPE)
+        every { dataStoreRepository.theme() } returns flowOf(FIRST_SAVED_THEME)
+        every { dataStoreRepository.fontType() } returns flowOf(FIRST_SAVED_FONT_TYPE)
         every { dataStoreRepository.enableInAppUpdate() } returns flowOf(FIRST_SAVED_ENABLE_IN_APP_UPDATE)
         viewModel = SettingsViewModel(
             dataStoreRepository = dataStoreRepository,
@@ -49,8 +49,8 @@ class SettingsViewModelTest {
             assertThat(uiState.fontType).isEqualTo(FIRST_SAVED_FONT_TYPE)
             assertThat(uiState.enableInAppUpdate).isEqualTo(FIRST_SAVED_ENABLE_IN_APP_UPDATE)
         }
-        coVerify(exactly = 1) { dataStoreRepository.selectedTheme() }
-        coVerify(exactly = 1) { dataStoreRepository.selectedFontType() }
+        coVerify(exactly = 1) { dataStoreRepository.theme() }
+        coVerify(exactly = 1) { dataStoreRepository.fontType() }
         coVerify(exactly = 1) { dataStoreRepository.enableInAppUpdate() }
     }
 


### PR DESCRIPTION
## Issue
- #254

## Overview
- DataStoreからFlowで受け取っているメソッドが`selectedTheme`とか`selectedFontType`になっていたから`theme`とか`fontType`に変更した(NIAを参考にした)
- DBからFlowで受け取っているメソッドが`getAllConvertHistory`になっていたから`observeAllConvertHistory`に変更した