### PR TITLE
共有の受け取る側の機能を追加する

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,12 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
         </activity>
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"

--- a/app/src/main/java/ksnd/hiraganaconverter/view/MainActivity.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/MainActivity.kt
@@ -81,7 +81,6 @@ class MainActivity : AppCompatActivity() {
         val splashScreen = installSplashScreen()
         splashScreen.setKeepOnScreenCondition { isAnimateSplash }
 
-
         enableEdgeToEdge()
 
         setContent {
@@ -148,7 +147,7 @@ class MainActivity : AppCompatActivity() {
                         MutableCreationExtras(defaultViewModelCreationExtras).apply {
                             set(DEFAULT_ARGS_KEY, bundleOf(NavKey.RECEIVED_TEXT to receivedText))
                         }
-                    }
+                    },
                 )
 
                 Column {

--- a/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/NavKey.kt
+++ b/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/NavKey.kt
@@ -1,0 +1,7 @@
+package ksnd.hiraganaconverter.core.domain
+
+class NavKey {
+    companion object {
+        const val RECEIVED_TEXT = "received_text"
+    }
+}

--- a/feature/converter/src/main/java/ksnd/hiraganaconverter/feature/converter/ConvertViewModelImpl.kt
+++ b/feature/converter/src/main/java/ksnd/hiraganaconverter/feature/converter/ConvertViewModelImpl.kt
@@ -1,5 +1,6 @@
 package ksnd.hiraganaconverter.feature.converter
 
+import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -8,6 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import ksnd.hiraganaconverter.core.domain.NavKey
 import ksnd.hiraganaconverter.core.domain.usecase.ConversionFailedException
 import ksnd.hiraganaconverter.core.domain.usecase.ConvertTextUseCase
 import ksnd.hiraganaconverter.core.domain.usecase.InterceptorError
@@ -22,10 +24,17 @@ import javax.inject.Inject
 class ConvertViewModelImpl @Inject constructor(
     private val convertTextUseCase: ConvertTextUseCase,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher,
+    savedStateHandle: SavedStateHandle,
 ) : ConvertViewModel() {
+    private val receivedText = savedStateHandle.get<String>(NavKey.RECEIVED_TEXT) ?: ""
 
     private val _uiState = MutableStateFlow(ConvertUiState())
     override val uiState: StateFlow<ConvertUiState> = _uiState.asStateFlow()
+
+    init {
+        if (receivedText.isNotEmpty()) _uiState.update { it.copy(inputText = receivedText) }
+        savedStateHandle.remove<String>(NavKey.RECEIVED_TEXT)
+    }
 
     override fun convert() {
         // If input has not changed since the last time, it will not be converted.

--- a/feature/converter/src/test/java/ksnd/hiraganaconverter/feature/converter/ConvertViewModelImplTest.kt
+++ b/feature/converter/src/test/java/ksnd/hiraganaconverter/feature/converter/ConvertViewModelImplTest.kt
@@ -1,10 +1,12 @@
 package ksnd.hiraganaconverter.feature.converter
 
+import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
+import ksnd.hiraganaconverter.core.domain.NavKey
 import ksnd.hiraganaconverter.core.domain.usecase.ConversionFailedException
 import ksnd.hiraganaconverter.core.domain.usecase.ConvertTextUseCase
 import ksnd.hiraganaconverter.core.model.ui.HiraKanaType
@@ -23,7 +25,19 @@ class ConvertViewModelImplTest {
     private val viewModel = ConvertViewModelImpl(
         convertTextUseCase = convertTextUseCase,
         ioDispatcher = mainDispatcherRule.testDispatcher,
+        savedStateHandle = SavedStateHandle(),
     )
+
+    @Test
+    fun init_receivedText_isUpdated() {
+        val receivedText = "漢字"
+        val viewModel = ConvertViewModelImpl(
+            convertTextUseCase = convertTextUseCase,
+            ioDispatcher = mainDispatcherRule.testDispatcher,
+            savedStateHandle = SavedStateHandle().apply { set(NavKey.RECEIVED_TEXT, receivedText) },
+        )
+        assertThat(viewModel.uiState.value.inputText).isEqualTo(receivedText)
+    }
 
     @Test
     fun updateInputText_newInputText_isUpdated() {


### PR DESCRIPTION
## Issue
- fix #213 

## Overview
- 他のアプリから共有されたテキストを受け取れるようにした

## Reference
#### [DroidKaigi 2023 「共有」スライド](https://docs.google.com/presentation/d/1E6fMxGTHINPqvjzmoZbI3YGEqlcAWBESFJHz0577OiU/edit#slide=id.p)
- 全体的に参照した(特に`ShareCompat.IntentReader`)
#### [[AssistedInject] Integration with @HiltViewModel](https://github.com/google/dagger/issues/2287#issuecomment-1459123240)
- ViewModelに引数を渡すようにする際に参照した
#### [Android developers - Receive simple data from other apps](https://developer.android.com/training/sharing/receive)
- 全体的に参考にした

## Screenshot

https://github.com/kosenda/hiragana-converter/assets/60963155/fef27b69-08fe-46e5-8dfe-a1a75ae97d9f
