### PR TITLE
画面遷移のボタンの２度押しをできないようにする

### DIFF
--- a/app/src/main/java/ksnd/hiraganaconverter/view/navigation/Navigation.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/navigation/Navigation.kt
@@ -58,6 +58,10 @@ fun Navigation(
         }
     }
 
+    fun transitionScreen(navRoute: NavRoute) {
+        navController.navigate(navRoute.route) { launchSingleTop = true }
+    }
+
     fun NavGraphBuilder.fadeComposable(
         route: String,
         arguments: List<NamedNavArgument> = emptyList(),
@@ -121,9 +125,9 @@ fun Navigation(
                     TopBar(
                         modifier = Modifier.onSizeChanged { topBarHeight = it.height },
                         scrollBehavior = scrollBehavior,
-                        transitionHistory = { navController.navigate(NavRoute.History.route) },
-                        transitionSetting = { navController.navigate(NavRoute.Setting.route) },
-                        transitionInfo = { navController.navigate(NavRoute.Info.route) },
+                        transitionHistory = { transitionScreen(NavRoute.History) },
+                        transitionSetting = { transitionScreen(NavRoute.Setting) },
+                        transitionInfo = { transitionScreen(NavRoute.Info) },
                     )
                 },
                 topBarHeight = topBarHeight,


### PR DESCRIPTION
## Issue
- fix #264 

## Overview
- launchSingleTopを使用することにより何度も同じ画面に遷移しないようにした

