### PR TITLE
【リファクタ】ConvertViewModelのconvertの処理をなるべくConvertViewModelに書かないように変更する

### DIFF
--- a/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/usecase/ConvertTextUseCaseError.kt
+++ b/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/usecase/ConvertTextUseCaseError.kt
@@ -1,9 +1,29 @@
 package ksnd.hiraganaconverter.core.domain.usecase
 
-import java.lang.RuntimeException
+import ksnd.hiraganaconverter.core.model.ui.ConvertErrorType
+import timber.log.Timber
 
 sealed class ConvertTextUseCaseError : RuntimeException()
-// TODO object と data object の違いを調べて対処する
-object IsReachedConvertMaxLimitException : ConvertTextUseCaseError()
-object ConversionFailedException : ConvertTextUseCaseError()
-object InterceptorError : ConvertTextUseCaseError()
+data object IsReachedConvertMaxLimitException : ConvertTextUseCaseError()
+data object ConversionFailedException : ConvertTextUseCaseError()
+data object InterceptorError : ConvertTextUseCaseError()
+
+fun Throwable.toConvertErrorType(): ConvertErrorType = when (this) {
+    is IsReachedConvertMaxLimitException -> ConvertErrorType.REACHED_CONVERT_MAX_LIMIT
+    is ConversionFailedException -> ConvertErrorType.CONVERSION_FAILED
+    is InterceptorError -> when (this.message) {
+        ConvertErrorType.TOO_MANY_CHARACTER.name -> ConvertErrorType.TOO_MANY_CHARACTER
+        ConvertErrorType.RATE_LIMIT_EXCEEDED.name -> ConvertErrorType.RATE_LIMIT_EXCEEDED
+        ConvertErrorType.CONVERSION_FAILED.name -> ConvertErrorType.CONVERSION_FAILED
+        ConvertErrorType.INTERNAL_SERVER.name -> ConvertErrorType.INTERNAL_SERVER
+        ConvertErrorType.NETWORK.name -> ConvertErrorType.NETWORK
+        else -> {
+            Timber.w("InterceptorError: %s".format(this.message))
+            ConvertErrorType.CONVERSION_FAILED
+        }
+    }
+    else -> {
+        Timber.e("Not defined ConvertTextUseCaseException! throwable: $this")
+        ConvertErrorType.CONVERSION_FAILED
+    }
+}


### PR DESCRIPTION
## Issue
- fix #292 

## Overview
- 処理内容は変わっておらず、処理を移しただけ

## Reference
- [Kotlinのdata object](https://star-zero.medium.com/kotlin%E3%81%AEdata-object-5ffdee50833c)
data objectにした方がtoStringしたときにかなり見やすくなることとかが特に参考になった