### PR TITLE
Slack通知　失敗したときにも通知させる

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,13 +47,11 @@ jobs:
       - run:
           name: run-danger-file
           command: bundle exec danger --verbose
-  notify:
-    docker:
-      - image: cimg/base:stable
-    steps:
+
       - slack/notify:
           event: fail
           template: basic_fail_1
+
       - slack/notify:
           event: pass
           template: basic_success_1
@@ -61,11 +59,8 @@ jobs:
 workflows:
   test:
     jobs:
-      - build-and-test
-      - notify:
+      - build-and-test:
           context: slack-secrets
-          requires:
-            - build-and-test
 
 # ■ memo ■
 # チェックコマンド： circleci config validate

--- a/feature/setting/src/test/java/ksnd/hiraganaconverter/feature/setting/SettingsViewModelTest.kt
+++ b/feature/setting/src/test/java/ksnd/hiraganaconverter/feature/setting/SettingsViewModelTest.kt
@@ -29,11 +29,6 @@ class SettingsViewModelTest {
     private val analytics = spyk(MockAnalytics())
     private lateinit var viewModel : SettingsViewModel
 
-    @Test
-    fun `test 絶対に失敗するテスト`() {
-        assertThat(true).isFalse()
-    }
-
     @Before
     fun setUp() {
         // Test with different default values for UiState and initial values for the test.

--- a/feature/setting/src/test/java/ksnd/hiraganaconverter/feature/setting/SettingsViewModelTest.kt
+++ b/feature/setting/src/test/java/ksnd/hiraganaconverter/feature/setting/SettingsViewModelTest.kt
@@ -29,6 +29,11 @@ class SettingsViewModelTest {
     private val analytics = spyk(MockAnalytics())
     private lateinit var viewModel : SettingsViewModel
 
+    @Test
+    fun `test 絶対に失敗するテスト`() {
+        assertThat(true).isFalse()
+    }
+
     @Before
     fun setUp() {
         // Test with different default values for UiState and initial values for the test.


### PR DESCRIPTION
## Issue
- fix #315 

## Overview
- requiresは指定したものが成功した時のみ実行できることを知った
- command で細かく設定させるのも考えたけどjobを１個しか作ってないからいいやってなった