### PR TITLE
レビュー訴求をできるようにする - レビューを表示するためのデータ用のRepository作成

### DIFF
--- a/app/src/test/java/ksnd/hiraganaconverter/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/ksnd/hiraganaconverter/viewmodel/MainActivityViewModelTest.kt
@@ -126,8 +126,6 @@ class MainActivityViewModelTest {
 
             override suspend fun updateUseInAppUpdate(isUsed: Boolean) {}
 
-            override suspend fun countUpTotalConvertCount(): Int = 1
-
             suspend fun emit(theme: Theme) {
                 this.theme.emit(theme)
             }

--- a/core/data/src/main/java/ksnd/hiraganaconverter/core/data/PreferenceKeys.kt
+++ b/core/data/src/main/java/ksnd/hiraganaconverter/core/data/PreferenceKeys.kt
@@ -9,6 +9,5 @@ object PreferenceKeys {
     val FONT_TYPE = stringPreferencesKey("font_type")
     val LAST_CONVERT_DATE = stringPreferencesKey("last_convert_date")
     val TODAY_CONVERT_COUNT = intPreferencesKey("today_convert_count")
-    val TOTAL_CONVERT_COUNT = intPreferencesKey("total_convert_count")
     val ENABLE_IN_APP_UPDATE = booleanPreferencesKey("enable_in_app_update")
 }

--- a/core/data/src/main/java/ksnd/hiraganaconverter/core/data/di/DataStoreModule.kt
+++ b/core/data/src/main/java/ksnd/hiraganaconverter/core/data/di/DataStoreModule.kt
@@ -1,7 +1,10 @@
 package ksnd.hiraganaconverter.core.data.di
 
 import android.content.Context
+import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.core.Serializer
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
@@ -10,6 +13,11 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import ksnd.hiraganaconverter.core.model.ReviewInfo
+import java.io.InputStream
+import java.io.OutputStream
 import javax.inject.Singleton
 
 @Module
@@ -23,5 +31,30 @@ object DataStoreModule {
                 context.preferencesDataStoreFile("DataStore")
             },
         )
+    }
+
+    @Provides
+    @Singleton
+    fun provideCalcInputRequiredInterestDataStore(
+        @ApplicationContext context: Context,
+    ): DataStore<ReviewInfo> {
+        return DataStoreFactory.create(
+            serializer = ReviewInfoSerializer,
+            produceFile = { context.preferencesDataStoreFile("ReviewInfoDataStore") },
+        )
+    }
+}
+
+object ReviewInfoSerializer : Serializer<ReviewInfo> {
+    override val defaultValue = ReviewInfo()
+    override suspend fun readFrom(input: InputStream): ReviewInfo {
+        try {
+            return Json.decodeFromString(ReviewInfo.serializer(), input.readBytes().decodeToString())
+        } catch (serialization: SerializationException) {
+            throw CorruptionException("Unable to read data", serialization)
+        }
+    }
+    override suspend fun writeTo(t: ReviewInfo, output: OutputStream) {
+        output.write(Json.encodeToString(ReviewInfo.serializer(), t).encodeToByteArray())
     }
 }

--- a/core/data/src/main/java/ksnd/hiraganaconverter/core/data/di/ReviewInfoRepositoryModule.kt
+++ b/core/data/src/main/java/ksnd/hiraganaconverter/core/data/di/ReviewInfoRepositoryModule.kt
@@ -1,0 +1,19 @@
+package ksnd.hiraganaconverter.core.data.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import ksnd.hiraganaconverter.core.domain.repository.ConvertHistoryRepository
+import ksnd.hiraganaconverter.core.data.repository.ConvertHistoryRepositoryImpl
+import ksnd.hiraganaconverter.core.data.repository.ReviewInfoRepositoryImpl
+import ksnd.hiraganaconverter.core.domain.repository.ReviewInfoRepository
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ReviewInfoRepositoryModule {
+    @Binds
+    @Singleton
+    abstract fun bindConvertHistoryRepository(impl: ReviewInfoRepositoryImpl): ReviewInfoRepository
+}

--- a/core/data/src/main/java/ksnd/hiraganaconverter/core/data/repository/DataStoreRepositoryImpl.kt
+++ b/core/data/src/main/java/ksnd/hiraganaconverter/core/data/repository/DataStoreRepositoryImpl.kt
@@ -65,17 +65,6 @@ class DataStoreRepositoryImpl @Inject constructor(
             }
     }
 
-    private suspend fun getTotalConvertCount(): Int? {
-        return dataStore.data
-            .catch { exception ->
-                Timber.e("DataStore: %s".format(exception))
-                if (exception is IOException) emit(emptyPreferences())
-            }
-            .map { preferences ->
-                preferences[PreferenceKeys.TOTAL_CONVERT_COUNT]
-            }.firstOrNull()
-    }
-
     override fun enableInAppUpdate(): Flow<Boolean> {
         return dataStore.data
             .catch { exception ->
@@ -119,11 +108,5 @@ class DataStoreRepositoryImpl @Inject constructor(
 
     private suspend fun updateTodayConvertCount(convertCount: Int) {
         dataStore.edit { it[PreferenceKeys.TODAY_CONVERT_COUNT] = convertCount }
-    }
-
-    override suspend fun countUpTotalConvertCount(): Int {
-        val totalConvertCount = (getTotalConvertCount() ?: 0) + 1
-        dataStore.edit { it[PreferenceKeys.TOTAL_CONVERT_COUNT] = totalConvertCount }
-        return totalConvertCount
     }
 }

--- a/core/data/src/main/java/ksnd/hiraganaconverter/core/data/repository/ReviewInfoRepositoryImpl.kt
+++ b/core/data/src/main/java/ksnd/hiraganaconverter/core/data/repository/ReviewInfoRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package ksnd.hiraganaconverter.core.data.repository
+
+import androidx.datastore.core.DataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import ksnd.hiraganaconverter.core.domain.repository.ReviewInfoRepository
+import ksnd.hiraganaconverter.core.model.ReviewInfo
+import javax.inject.Inject
+
+class ReviewInfoRepositoryImpl @Inject constructor(
+    private val dataStore: DataStore<ReviewInfo>,
+) : ReviewInfoRepository {
+    override val reviewInfo: Flow<ReviewInfo> = dataStore.data
+
+    override suspend fun countUpTotalConvertCount(): Int {
+        val newCount = (reviewInfo.firstOrNull()?.totalConvertCount ?: 0) + 1
+        dataStore.updateData { it.copy(totalConvertCount = newCount) }
+        return newCount
+    }
+}

--- a/core/data/src/test/java/ksnd/hiraganaconverter/core/data/repository/DataStoreRepositoryImplTest.kt
+++ b/core/data/src/test/java/ksnd/hiraganaconverter/core/data/repository/DataStoreRepositoryImplTest.kt
@@ -77,14 +77,4 @@ class DataStoreRepositoryImplTest {
         dataStoreRepository.updateUseInAppUpdate(false)
         assertThat(dataStoreRepository.enableInAppUpdate().first()).isFalse()
     }
-
-    @Test
-    fun countUpTotalConvertCount_first_is1() = runTest {
-        assertThat(dataStoreRepository.countUpTotalConvertCount()).isEqualTo(1)
-    }
-
-    @Test
-    fun countUpTotalConvertCount_countUp_isCountUp() = runTest {
-        repeat(5) { assertThat(dataStoreRepository.countUpTotalConvertCount()).isEqualTo(it + 1) }
-    }
 }

--- a/core/data/src/test/java/ksnd/hiraganaconverter/core/data/repository/ReviewInfoRepositoryImplTest.kt
+++ b/core/data/src/test/java/ksnd/hiraganaconverter/core/data/repository/ReviewInfoRepositoryImplTest.kt
@@ -1,0 +1,38 @@
+package ksnd.hiraganaconverter.core.data.repository
+
+import android.content.Context
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import ksnd.hiraganaconverter.core.data.di.ReviewInfoSerializer
+import ksnd.hiraganaconverter.core.testing.MainDispatcherRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ReviewInfoRepositoryImplTest {
+    @get: Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val dataStore = DataStoreFactory.create(
+        serializer = ReviewInfoSerializer,
+        produceFile = { context.preferencesDataStoreFile("TestReviewInfoDataStore") },
+    )
+    private val repository = ReviewInfoRepositoryImpl(dataStore = dataStore)
+
+    @Test
+
+    fun countUpTotalConvertCount_first_is1() = runTest {
+        assertThat(repository.countUpTotalConvertCount()).isEqualTo(1)
+    }
+
+    @Test
+    fun countUpTotalConvertCount_countUp_isCountUp() = runTest {
+        repeat(5) { assertThat(repository.countUpTotalConvertCount()).isEqualTo(it + 1) }
+    }
+}

--- a/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/repository/DataStoreRepository.kt
+++ b/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/repository/DataStoreRepository.kt
@@ -12,5 +12,4 @@ interface DataStoreRepository {
     suspend fun updateFontType(fontType: FontType)
     suspend fun checkIsExceedingMaxLimit(): Boolean
     suspend fun updateUseInAppUpdate(isUsed: Boolean)
-    suspend fun countUpTotalConvertCount(): Int
 }

--- a/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/repository/ReviewInfoRepository.kt
+++ b/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/repository/ReviewInfoRepository.kt
@@ -1,0 +1,9 @@
+package ksnd.hiraganaconverter.core.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+import ksnd.hiraganaconverter.core.model.ReviewInfo
+
+interface ReviewInfoRepository {
+    val reviewInfo: Flow<ReviewInfo>
+    suspend fun countUpTotalConvertCount(): Int
+}

--- a/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/usecase/ConvertTextUseCase.kt
+++ b/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/usecase/ConvertTextUseCase.kt
@@ -6,6 +6,7 @@ import ksnd.hiraganaconverter.core.analytics.Analytics
 import ksnd.hiraganaconverter.core.domain.repository.ConvertHistoryRepository
 import ksnd.hiraganaconverter.core.domain.repository.ConvertRepository
 import ksnd.hiraganaconverter.core.domain.repository.DataStoreRepository
+import ksnd.hiraganaconverter.core.domain.repository.ReviewInfoRepository
 import ksnd.hiraganaconverter.core.model.ui.HiraKanaType
 import ksnd.hiraganaconverter.core.resource.AppConfig
 import ksnd.hiraganaconverter.core.resource.di.IODispatcher
@@ -16,12 +17,13 @@ class ConvertTextUseCase @Inject constructor(
     private val convertRepository: ConvertRepository,
     private val dataStoreRepository: DataStoreRepository,
     private val convertHistoryRepository: ConvertHistoryRepository,
+    private val reviewInfoRepository: ReviewInfoRepository,
     private val appConfig: AppConfig,
     private val analytics: Analytics,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
     suspend operator fun invoke(inputText: String, selectedTextType: HiraKanaType): String = withContext(ioDispatcher) {
-        val totalConvertCount = dataStoreRepository.countUpTotalConvertCount()
+        val totalConvertCount = reviewInfoRepository.countUpTotalConvertCount()
         analytics.logTotalConvertCount(count = totalConvertCount)
 
         val isReachedConvertMaxLimit = dataStoreRepository.checkIsExceedingMaxLimit()

--- a/core/model/src/main/java/ksnd/hiraganaconverter/core/model/ReviewInfo.kt
+++ b/core/model/src/main/java/ksnd/hiraganaconverter/core/model/ReviewInfo.kt
@@ -1,0 +1,10 @@
+package ksnd.hiraganaconverter.core.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReviewInfo(
+    val isAlreadyReviewed: Boolean = false,
+    val totalConvertCount: Int = 0,
+    val lastRequestReviewLocalDateStr: String? = null,
+)


### PR DESCRIPTION
## Issue
- #322 

## Overview
- 前回のPRで作成した累計変換回数を新しく作った`ReviewInfoRepository`に移した
- Proto DataStoreを使用するようにして、１つのクラスでReview用のデータを管理するようにした
