### PR TITLE
レビュー訴求をできるようにする - 最終レビュー訴求日を文字列でなくLocalDateとして保存

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(libs.retrofit)
     implementation(libs.retrofit.kotlinx.serialization.converter)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.datetime)
     implementation(libs.okhttp3)
     implementation(libs.okhttp3.logging.interceptor)
 

--- a/core/data/src/main/java/ksnd/hiraganaconverter/core/data/repository/ReviewInfoRepositoryImpl.kt
+++ b/core/data/src/main/java/ksnd/hiraganaconverter/core/data/repository/ReviewInfoRepositoryImpl.kt
@@ -3,6 +3,9 @@ package ksnd.hiraganaconverter.core.data.repository
 import androidx.datastore.core.DataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
 import ksnd.hiraganaconverter.core.domain.repository.ReviewInfoRepository
 import ksnd.hiraganaconverter.core.model.ReviewInfo
 import javax.inject.Inject
@@ -16,5 +19,9 @@ class ReviewInfoRepositoryImpl @Inject constructor(
         val newCount = (reviewInfo.firstOrNull()?.totalConvertCount ?: 0) + 1
         dataStore.updateData { it.copy(totalConvertCount = newCount) }
         return newCount
+    }
+
+    override suspend fun updateLastRequestReviewLocalDate() {
+        dataStore.updateData { it.copy(lastRequestReviewLocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault())) }
     }
 }

--- a/core/data/src/test/java/ksnd/hiraganaconverter/core/data/repository/ReviewInfoRepositoryImplTest.kt
+++ b/core/data/src/test/java/ksnd/hiraganaconverter/core/data/repository/ReviewInfoRepositoryImplTest.kt
@@ -4,9 +4,14 @@ import android.content.Context
 import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.preferences.preferencesDataStoreFile
 import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
 import ksnd.hiraganaconverter.core.data.di.ReviewInfoSerializer
+import ksnd.hiraganaconverter.core.model.ReviewInfo
 import ksnd.hiraganaconverter.core.testing.MainDispatcherRule
 import org.junit.Rule
 import org.junit.Test
@@ -26,13 +31,31 @@ class ReviewInfoRepositoryImplTest {
     private val repository = ReviewInfoRepositoryImpl(dataStore = dataStore)
 
     @Test
-
     fun countUpTotalConvertCount_first_is1() = runTest {
-        assertThat(repository.countUpTotalConvertCount()).isEqualTo(1)
+        repository.reviewInfo.test {
+            assertThat(awaitItem()).isEqualTo(ReviewInfo())
+            assertThat(repository.countUpTotalConvertCount()).isEqualTo(1)
+            assertThat(awaitItem()).isEqualTo(ReviewInfo().copy(totalConvertCount = 1))
+        }
     }
 
     @Test
     fun countUpTotalConvertCount_countUp_isCountUp() = runTest {
-        repeat(5) { assertThat(repository.countUpTotalConvertCount()).isEqualTo(it + 1) }
+        repository.reviewInfo.test {
+            assertThat(awaitItem()).isEqualTo(ReviewInfo())
+            repeat(5) {
+                assertThat(repository.countUpTotalConvertCount()).isEqualTo(it + 1)
+                assertThat(awaitItem()).isEqualTo(ReviewInfo().copy(totalConvertCount = it + 1))
+            }
+        }
+    }
+
+    @Test
+    fun updateLastRequestReviewLocalDate_isToday() = runTest {
+        repository.reviewInfo.test {
+            assertThat(awaitItem()).isEqualTo(ReviewInfo())
+            repository.updateLastRequestReviewLocalDate()
+            assertThat(awaitItem()).isEqualTo(ReviewInfo().copy(lastRequestReviewLocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault())))
+        }
     }
 }

--- a/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/repository/ReviewInfoRepository.kt
+++ b/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/repository/ReviewInfoRepository.kt
@@ -6,4 +6,5 @@ import ksnd.hiraganaconverter.core.model.ReviewInfo
 interface ReviewInfoRepository {
     val reviewInfo: Flow<ReviewInfo>
     suspend fun countUpTotalConvertCount(): Int
+    suspend fun updateLastRequestReviewLocalDate()
 }

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -11,4 +11,6 @@ android {
 dependencies {
     // kotlinx serialization
     implementation(libs.kotlinx.serialization.json)
+    // kotlinx datetime
+    implementation(libs.kotlinx.datetime)
 }

--- a/core/model/src/main/java/ksnd/hiraganaconverter/core/model/ReviewInfo.kt
+++ b/core/model/src/main/java/ksnd/hiraganaconverter/core/model/ReviewInfo.kt
@@ -1,10 +1,11 @@
 package ksnd.hiraganaconverter.core.model
 
+import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class ReviewInfo(
     val isAlreadyReviewed: Boolean = false,
     val totalConvertCount: Int = 0,
-    val lastRequestReviewLocalDateStr: String? = null,
+    val lastRequestReviewLocalDate: LocalDate? = null,
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ hilt = "2.48.1"
 junit4 = "4.13.2"
 kotlin = "1.9.10"
 kotlinxSerializationJson = "1.6.0"
+kotlinxDatetime = "0.4.1"
 ksp = "1.9.10-1.0.13"
 ktlint = "1.0.1"
 lottie = "6.1.0"
@@ -70,6 +71,7 @@ androidx-test-core = { group = "androidx.test", name = "core", version.ref = "an
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutineTest" }
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
+kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }
 
 # Coil
 coil = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }


### PR DESCRIPTION
## Issue
- #322

## Overview
- `kotlinx-datetime`を使用してLocalDateを保存するようにした
- テストもちょっと追加した
- 他にjava.util.LocalDateを使用しているところがたくさんあるが、`kotlinx-datetime`に移行しようと思う