### PR TITLE
レビュー訴求をできるようにする - ダイアログの追加など

### DIFF
--- a/app/src/main/java/ksnd/hiraganaconverter/view/RequestReviewDialog.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/RequestReviewDialog.kt
@@ -1,0 +1,58 @@
+package ksnd.hiraganaconverter.view
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import ksnd.hiraganaconverter.core.resource.R
+import ksnd.hiraganaconverter.core.ui.preview.UiModeAndLocalePreview
+import ksnd.hiraganaconverter.core.ui.theme.HiraganaConverterTheme
+
+@Composable
+fun RequestReviewDialog(onLater: () -> Unit, onOk: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = {},
+        title = {
+            Text(
+                text = stringResource(id = R.string.request_review_title),
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        },
+        text = {
+            Text(
+                text = stringResource(id = R.string.request_review_desc),
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onOk) {
+                Text(
+                    text = stringResource(id = R.string.ok),
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onLater) {
+                Text(
+                    text = stringResource(id = R.string.request_review_cancel),
+                    color = MaterialTheme.colorScheme.secondary,
+                )
+            }
+        },
+        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+    )
+}
+
+@UiModeAndLocalePreview
+@Composable
+private fun PreviewRequestReviewDialog() {
+    HiraganaConverterTheme {
+        RequestReviewDialog(
+            onLater = {},
+            onOk = {},
+        )
+    }
+}

--- a/app/src/main/java/ksnd/hiraganaconverter/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/viewmodel/MainActivityViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.launch
 import ksnd.hiraganaconverter.core.data.inappupdate.InAppUpdateState
 import ksnd.hiraganaconverter.core.domain.inappupdate.InAppUpdateManager
 import ksnd.hiraganaconverter.core.domain.repository.DataStoreRepository
+import ksnd.hiraganaconverter.core.domain.usecase.CancelReviewUseCase
 import ksnd.hiraganaconverter.core.domain.usecase.CompletedRequestReviewUseCase
 import ksnd.hiraganaconverter.core.domain.usecase.ObserveNeedRequestReviewUseCase
 import ksnd.hiraganaconverter.view.MainActivityUiState
@@ -29,6 +30,7 @@ class MainActivityViewModel @Inject constructor(
     private val dataStoreRepository: DataStoreRepository,
     private val inAppUpdateManager: InAppUpdateManager,
     private val completedRequestReviewUseCase: CompletedRequestReviewUseCase,
+    private val cancelReviewUseCase: CancelReviewUseCase,
 ) : ViewModel(), InstallStateUpdatedListener {
     private val inAppUpdateState: MutableStateFlow<InAppUpdateState> = MutableStateFlow(InAppUpdateState.Requesting)
 
@@ -80,6 +82,12 @@ class MainActivityViewModel @Inject constructor(
     fun completedRequestReview() {
         viewModelScope.launch {
             completedRequestReviewUseCase()
+        }
+    }
+
+    fun cancelledReview() {
+        viewModelScope.launch {
+            cancelReviewUseCase()
         }
     }
 

--- a/app/src/test/java/ksnd/hiraganaconverter/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/ksnd/hiraganaconverter/viewmodel/MainActivityViewModelTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.test.runTest
 import ksnd.hiraganaconverter.core.data.inappupdate.InAppUpdateState
 import ksnd.hiraganaconverter.core.domain.inappupdate.InAppUpdateManager
 import ksnd.hiraganaconverter.core.domain.repository.DataStoreRepository
+import ksnd.hiraganaconverter.core.domain.usecase.CancelReviewUseCase
 import ksnd.hiraganaconverter.core.domain.usecase.CompletedRequestReviewUseCase
 import ksnd.hiraganaconverter.core.domain.usecase.ObserveNeedRequestReviewUseCase
 import ksnd.hiraganaconverter.core.model.ui.FontType
@@ -35,6 +36,7 @@ class MainActivityViewModelTest {
     private val inAppUpdateManager = mockk<InAppUpdateManager>(relaxed = true)
     private val observeNeedRequestReviewUseCase = mockk<ObserveNeedRequestReviewUseCase>(relaxUnitFun = true)
     private val completedRequestReviewUseCase = mockk<CompletedRequestReviewUseCase>(relaxUnitFun = true)
+    private val cancelReviewUseCase = mockk<CancelReviewUseCase>(relaxUnitFun = true)
 
     private lateinit var viewModel: MainActivityViewModel
 
@@ -46,6 +48,7 @@ class MainActivityViewModelTest {
             inAppUpdateManager = inAppUpdateManager,
             observeNeedRequestReviewUseCase = observeNeedRequestReviewUseCase,
             completedRequestReviewUseCase = completedRequestReviewUseCase,
+            cancelReviewUseCase = cancelReviewUseCase,
         )
     }
 
@@ -114,11 +117,16 @@ class MainActivityViewModelTest {
         }
 
     @Test
-    fun completedRequestReview_callUseCase() =
-        runTest {
-            viewModel.completedRequestReview()
-            coVerify(exactly = 1) { completedRequestReviewUseCase() }
-        }
+    fun completedRequestReview_callUseCase() = runTest {
+        viewModel.completedRequestReview()
+        coVerify(exactly = 1) { completedRequestReviewUseCase() }
+    }
+
+    @Test
+    fun cancelReview_callUseCase() = runTest {
+        viewModel.cancelledReview()
+        coVerify(exactly = 1) { cancelReviewUseCase() }
+    }
 
     companion object {
         class FakeDataStoreRepository : DataStoreRepository {

--- a/core/analytics/src/main/java/ksnd/hiraganaconverter/core/analytics/Analytics.kt
+++ b/core/analytics/src/main/java/ksnd/hiraganaconverter/core/analytics/Analytics.kt
@@ -11,4 +11,5 @@ interface Analytics {
     fun logUpdateFont(font: String)
     fun logSwitchEnableInAppUpdate(isEnable: Boolean)
     fun logTotalConvertCount(count: Int)
+    fun logRequestReview()
 }

--- a/core/analytics/src/main/java/ksnd/hiraganaconverter/core/analytics/AnalyticsImpl.kt
+++ b/core/analytics/src/main/java/ksnd/hiraganaconverter/core/analytics/AnalyticsImpl.kt
@@ -65,4 +65,8 @@ class AnalyticsImpl @Inject constructor(
             param(Param.COUNT.name, count.toString())
         }
     }
+
+    override fun logRequestReview() {
+        firebaseAnalytics.logEvent(Event.REQUEST_REVIEW.name) {}
+    }
 }

--- a/core/analytics/src/main/java/ksnd/hiraganaconverter/core/analytics/MockAnalytics.kt
+++ b/core/analytics/src/main/java/ksnd/hiraganaconverter/core/analytics/MockAnalytics.kt
@@ -14,4 +14,5 @@ class MockAnalytics : Analytics {
     override fun logUpdateFont(font: String) {}
     override fun logSwitchEnableInAppUpdate(isEnable: Boolean) {}
     override fun logTotalConvertCount(count: Int) {}
+    override fun logRequestReview() {}
 }

--- a/core/analytics/src/main/java/ksnd/hiraganaconverter/core/analytics/Params.kt
+++ b/core/analytics/src/main/java/ksnd/hiraganaconverter/core/analytics/Params.kt
@@ -18,6 +18,7 @@ enum class Event {
     UPDATE_FONT,
     SWITCH_ENABLE_IN_APP_UPDATE,
     COUNT_UP_TOTAL_CONVERT_COUNT,
+    REQUEST_REVIEW,
 }
 
 enum class Param {

--- a/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/usecase/CancelReviewUseCase.kt
+++ b/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/usecase/CancelReviewUseCase.kt
@@ -1,0 +1,16 @@
+package ksnd.hiraganaconverter.core.domain.usecase
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import ksnd.hiraganaconverter.core.domain.repository.ReviewInfoRepository
+import ksnd.hiraganaconverter.core.resource.di.IODispatcher
+import javax.inject.Inject
+
+class CancelReviewUseCase @Inject constructor(
+    private val reviewInfoRepository: ReviewInfoRepository,
+    @IODispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
+    suspend operator fun invoke(): Unit = withContext(ioDispatcher) {
+        reviewInfoRepository.updateLastRequestReviewLocalDate()
+    }
+}

--- a/core/domain/src/test/java/ksnd/hiraganaconverter/core/domain/usecase/CancelReviewUseCaseTest.kt
+++ b/core/domain/src/test/java/ksnd/hiraganaconverter/core/domain/usecase/CancelReviewUseCaseTest.kt
@@ -11,20 +11,20 @@ import ksnd.hiraganaconverter.core.testing.MainDispatcherRule
 import org.junit.Rule
 import org.junit.Test
 
-class CompletedRequestReviewUseCaseTest {
+class CancelReviewUseCaseTest {
     @get: Rule
     val mainDispatcherRule = MainDispatcherRule()
 
     private val reviewInfoRepository = mockk<ReviewInfoRepository>(relaxUnitFun = true)
-    private val useCase = CompletedRequestReviewUseCase(
+    private val useCase = CancelReviewUseCase(
         reviewInfoRepository = reviewInfoRepository,
         ioDispatcher = mainDispatcherRule.testDispatcher,
     )
 
     @Test
-    fun useCase_completedRequestReview() = runTest {
-        coEvery { reviewInfoRepository.completedRequestReview() } just runs
+    fun useCase_callUpdateLastRequestReviewLocalDate() = runTest {
+        coEvery { reviewInfoRepository.updateLastRequestReviewLocalDate() } just runs
         useCase()
-        coVerify(exactly = 1) { reviewInfoRepository.completedRequestReview() }
+        coVerify(exactly = 1) { reviewInfoRepository.updateLastRequestReviewLocalDate() }
     }
 }

--- a/core/resource/src/main/res/values-ja/strings.xml
+++ b/core/resource/src/main/res/values-ja/strings.xml
@@ -34,6 +34,11 @@
     <string name="in_app_update_setting">アプリ内アップデート</string>
     <string name="in_app_update_show_update">アップデートを表示する</string>
 
+    <!-- Request Review -->
+    <string name="request_review_title">お願い</string>
+    <string name="request_review_desc">アプリのレビューをしていただけないでしょうか？</string>
+    <string name="request_review_cancel">後で</string>
+
     <string-array name="conversion_type">
         <item>ひらがな</item>
         <item>カタカナ</item>

--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -34,6 +34,11 @@
     <string name="in_app_update_setting">In app update</string>
     <string name="in_app_update_show_update">Show update</string>
 
+    <!-- Request Review -->
+    <string name="request_review_title">Request</string>
+    <string name="request_review_desc">Could you please review the application?</string>
+    <string name="request_review_cancel">Later</string>
+
     <string-array name="conversion_type">
         <item>ひらがな</item>
         <item>カタカナ</item>
@@ -47,6 +52,7 @@
     <string name="version_title" translatable="false">App Version</string>
     <string name="app_info_title" translatable="false">App Info</string>
     <string name="app_name_title" translatable="false">App Name</string>
+    <string name="ok" translatable="false">OK</string>
 
     <string name="developer_name_title" translatable="false">Developer</string>
     <string name="developer_name" translatable="false">KSND</string>


### PR DESCRIPTION
## Issue
- fix #322 

## Overview
- レビューしてもらうためにダイアログを表示して、OKだったらキャンセルされたとしてもデータが消えない限り二度と表示されず、後でだったら数日たっているかつ所定の回数で割り切れたときにレビューを訴求するようにした
- 実機でのテストは実施済み