### PR TITLE
[バグ修正] パディングとCoroutineDispatchersが間違っている

### DIFF
--- a/core/data/src/main/java/ksnd/hiraganaconverter/core/data/repository/ConvertHistoryRepositoryImpl.kt
+++ b/core/data/src/main/java/ksnd/hiraganaconverter/core/data/repository/ConvertHistoryRepositoryImpl.kt
@@ -1,18 +1,22 @@
 package ksnd.hiraganaconverter.core.data.repository
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
 import ksnd.hiraganaconverter.core.domain.repository.ConvertHistoryRepository
 import ksnd.hiraganaconverter.core.model.ConvertHistoryData
 import ksnd.hiraganaconverter.core.resource.TimeFormat
 import ksnd.hiraganaconverter.core.data.database.ConvertHistoryDao
+import ksnd.hiraganaconverter.core.resource.di.IODispatcher
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 class ConvertHistoryRepositoryImpl @Inject constructor(
     private val convertHistoryDao: ConvertHistoryDao,
+    @IODispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ConvertHistoryRepository {
-    override fun insertConvertHistory(beforeText: String, afterText: String) {
+    override suspend fun insertConvertHistory(beforeText: String, afterText: String) = withContext(ioDispatcher) {
         convertHistoryDao.insertConvertHistory(
             convertHistoryData = ConvertHistoryData(
                 before = beforeText,
@@ -25,10 +29,11 @@ class ConvertHistoryRepositoryImpl @Inject constructor(
     override fun observeAllConvertHistory(): Flow<List<ConvertHistoryData>> =
         convertHistoryDao.observeAllConvertHistory()
 
-    override fun deleteAllConvertHistory() =
+    override suspend fun deleteAllConvertHistory() = withContext(ioDispatcher) {
         convertHistoryDao.deleteAllConvertHistory()
+    }
 
-    override fun deleteConvertHistory(id: Long) {
+    override suspend fun deleteConvertHistory(id: Long) = withContext(ioDispatcher) {
         convertHistoryDao.deleteConvertHistory(id)
     }
 }

--- a/core/data/src/test/java/ksnd/hiraganaconverter/core/data/repository/ConvertHistoryRepositoryImplTest.kt
+++ b/core/data/src/test/java/ksnd/hiraganaconverter/core/data/repository/ConvertHistoryRepositoryImplTest.kt
@@ -7,9 +7,9 @@ import io.mockk.verify
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.test.runTest
-import ksnd.hiraganaconverter.core.testing.MainDispatcherRule
 import ksnd.hiraganaconverter.core.data.database.ConvertHistoryDao
 import ksnd.hiraganaconverter.core.data.database.RoomRule
+import ksnd.hiraganaconverter.core.testing.MainDispatcherRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,7 +25,10 @@ class ConvertHistoryRepositoryImplTest {
 
     private val convertHistoryDao = spyk<ConvertHistoryDao>(roomRule.dao)
 
-    private val convertHistoryRepositoryImpl = ConvertHistoryRepositoryImpl(convertHistoryDao = convertHistoryDao)
+    private val convertHistoryRepositoryImpl = ConvertHistoryRepositoryImpl(
+        convertHistoryDao = convertHistoryDao,
+        ioDispatcher = mainDispatcherRule.testDispatcher,
+    )
 
     @Test
     fun observeAllConvertHistory_initial_isEmpty() = runTest {

--- a/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/repository/ConvertHistoryRepository.kt
+++ b/core/domain/src/main/java/ksnd/hiraganaconverter/core/domain/repository/ConvertHistoryRepository.kt
@@ -4,8 +4,8 @@ import kotlinx.coroutines.flow.Flow
 import ksnd.hiraganaconverter.core.model.ConvertHistoryData
 
 interface ConvertHistoryRepository {
-    fun insertConvertHistory(beforeText: String, afterText: String)
+    suspend fun insertConvertHistory(beforeText: String, afterText: String)
     fun observeAllConvertHistory(): Flow<List<ConvertHistoryData>>
-    fun deleteAllConvertHistory()
-    fun deleteConvertHistory(id: Long)
+    suspend fun deleteAllConvertHistory()
+    suspend fun deleteConvertHistory(id: Long)
 }

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/BackTopBar.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/BackTopBar.kt
@@ -28,10 +28,12 @@ import ksnd.hiraganaconverter.core.ui.theme.HiraganaConverterTheme
 @Composable
 fun BackTopBar(
     scrollBehavior: TopAppBarScrollBehavior,
+    modifier: Modifier = Modifier,
     onBackPressed: () -> Unit,
 ) {
     TopAppBar(
         title = {},
+        modifier = modifier,
         scrollBehavior = scrollBehavior,
         navigationIcon = {
             Box(

--- a/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/ConvertHistoryScreen.kt
+++ b/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/ConvertHistoryScreen.kt
@@ -1,6 +1,7 @@
 package ksnd.hiraganaconverter.feature.history
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -82,6 +83,9 @@ private fun ConvertHistoryScreenContent(
     val layoutDirection = LocalLayoutDirection.current
 
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+            .background(MaterialTheme.colorScheme.surface)
+            .displayCutoutPadding(),
         topBar = {
             BackTopBar(scrollBehavior = scrollBehavior, onBackPressed = onBackPressed)
         }
@@ -97,7 +101,6 @@ private fun ConvertHistoryScreenContent(
 
         Column(
             modifier = Modifier
-                .displayCutoutPadding()
                 .padding(
                     paddingValues = PaddingValues(
                         start = padding.calculateStartPadding(layoutDirection),
@@ -110,9 +113,7 @@ private fun ConvertHistoryScreenContent(
             if (state.convertHistories.isEmpty()) {
                 EmptyHistoryImage()
             } else {
-                LazyColumn(
-                    modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-                ) {
+                LazyColumn {
                     item {
                         Row {
                             Spacer(modifier = Modifier.weight(1f))

--- a/feature/info/src/main/java/ksnd/hiraganaconverter/feature/info/InfoScreen.kt
+++ b/feature/info/src/main/java/ksnd/hiraganaconverter/feature/info/InfoScreen.kt
@@ -2,6 +2,7 @@ package ksnd.hiraganaconverter.feature.info
 
 import android.content.Intent
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
@@ -94,6 +95,9 @@ private fun InfoScreenContent(
     var isShowMovesToApiSiteDialog by remember { mutableStateOf(false) }
 
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+            .background(MaterialTheme.colorScheme.surface)
+            .displayCutoutPadding(),
         topBar = {
             BackTopBar(scrollBehavior = scrollBehavior, onBackPressed = onBackPressed)
         },
@@ -125,7 +129,6 @@ private fun InfoScreenContent(
 
         Column(
             modifier = Modifier
-                .displayCutoutPadding()
                 .padding(
                     paddingValues = PaddingValues(
                         start = padding.calculateStartPadding(layoutDirection),
@@ -133,7 +136,6 @@ private fun InfoScreenContent(
                         end = padding.calculateEndPadding(layoutDirection)
                     ),
                 )
-                .nestedScroll(scrollBehavior.nestedScrollConnection)
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 16.dp)
                 .fillMaxSize(),

--- a/feature/setting/src/main/java/ksnd/hiraganaconverter/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/ksnd/hiraganaconverter/feature/setting/SettingScreen.kt
@@ -1,5 +1,6 @@
 package ksnd.hiraganaconverter.feature.setting
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -86,7 +87,9 @@ private fun SettingScreenContent(
     }
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+            .background(MaterialTheme.colorScheme.surface)
+            .displayCutoutPadding(),
         topBar = {
             BackTopBar(scrollBehavior = scrollBehavior, onBackPressed = onBackPressed)
         },


### PR DESCRIPTION
## Overview
- パディングは、情報画面・設定画面・変換履歴画面のTopAppBarの下に変な隙間ができていた
- 履歴画面の全て削除ボタンを押下するとMainDispatcherで処理をしようとしてクラッシュしていた....
