### PR TITLE
KotlinとComposeのバージョンを上げる

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ accompanist = "0.32.0"
 activity = "1.8.1"
 androidGradlePlugin = "8.1.4"
 androidxAppCompat = "1.7.0-alpha03"
+androidxCompose = "1.6.0-beta01"
 androidxComposeMaterial3 = "1.2.0-alpha11"
 androidxCore = "1.12.0"
 androidxCoreSplashscreen = "1.0.1"
@@ -11,7 +12,6 @@ androidxHilt = "1.1.0"
 androidxLifecycle = "2.6.2"
 androidxNavigation = "2.7.5"
 androidxTestCore = "1.5.0"
-androidxUi = "1.5.4"
 appUpdate = "2.1.0"
 coil = "2.5.0"
 coroutines = "1.7.3"
@@ -23,7 +23,7 @@ firebaseCrashlyticsPlugin = "2.9.9"
 firebasePerfPlugin = "1.4.2"
 hilt = "2.48.1"
 junit4 = "4.13.2"
-kotlin = "1.9.10"
+kotlin = "1.9.20"
 kotlinxSerializationJson = "1.6.1"
 kotlinxDatetime = "0.4.1"
 ksp = "1.9.20-1.0.14"
@@ -46,7 +46,7 @@ mockk = "1.13.8"
 roborazzi = "1.6.0"
 
 # ** I'm using it, so no deletions allowed. **
-androidxComposeCompiler = "1.5.3"
+androidxComposeCompiler = "1.5.4"
 jacoco = "0.8.9"
 
 [libraries]
@@ -57,12 +57,12 @@ accompanist-webView = { group = "com.google.accompanist", name = "accompanist-we
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "androidxComposeMaterial3" }
-androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime", version.ref = "androidxUi" }
-androidx-compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "androidxUi" }
-androidx-compose-ui-google-fonts = { group = "androidx.compose.ui", name = "ui-text-google-fonts", version.ref = "androidxUi" }
-androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "androidxUi" }
-androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "androidxUi" }
-androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "androidxUi" }
+androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime", version.ref = "androidxCompose" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "androidxCompose" }
+androidx-compose-ui-google-fonts = { group = "androidx.compose.ui", name = "ui-text-google-fonts", version.ref = "androidxCompose" }
+androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "androidxCompose" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "androidxCompose" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "androidxCompose" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "androidxCoreSplashscreen" }
 androidx-dataStore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidxDataStore" }


### PR DESCRIPTION
LazyColumnの末尾を削除するとクラッシュしていたから、Composeのバージョンを1.5.3から1.6.0-beta01に変更した
https://x.com/ksnd_dev/status/1726156323761561620?s=20

あと、versionの名前もcomposeの方が良いと思ったから変えた