### PR TITLE
composeCompilerReports

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,3 +64,22 @@ tasks.create<JacocoReport>("mergeJacoco") {
         }
     }
 }
+
+subprojects {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        kotlinOptions {
+            if (project.findProperty("composeCompilerReports") == "true") {
+                freeCompilerArgs += listOf(
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=${project.buildDir.absolutePath}/compose_compiler"
+                )
+            }
+            if (project.findProperty("composeCompilerMetrics") == "true") {
+                freeCompilerArgs += listOf(
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=${project.buildDir.absolutePath}/compose_compiler"
+                )
+            }
+        }
+    }
+}

--- a/core/resource/build.gradle.kts
+++ b/core/resource/build.gradle.kts
@@ -6,3 +6,8 @@ plugins {
 android {
     namespace = "ksnd.hiraganaconverter.core.resource"
 }
+
+dependencies {
+    implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.core.splashscreen)
+}


### PR DESCRIPTION
## Overview
- composeCompilerReportsを見れるようにした
- resourceのlintエラーの修正（依存が足りてなかった）

## Reference
- [Diagnose stability issues](https://developer.android.com/jetpack/compose/performance/stability/diagnose#kotlin)
