### PR TITLE
gradle.propertiesからbuildconfigを削除

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = libs.versions.androidxComposeCompiler.get()

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,3 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 org.gradle.caching=true
-
-# https://stackoverflow.com/questions/60942575/unresolved-reference-buildconfig-in-kotlin
-android.defaults.buildfeatures.buildconfig=true


### PR DESCRIPTION
## Overview
- gradle 9.0で廃止されると警告が結構出てたから対応
