### PR TITLE
Circle Ci 全体的に見直し（勉強兼ねて）

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,9 @@ commands:
             echo "apiKey=$.Environment.DEBUG_AD_APPLICATION_ID" >> $LOCAL_PROPERTIES_PATH
 
 jobs:
-  dependencies:
+  build-and-test:
     executor: android
+    context: slack-secrets
     steps:
       - checkout
       - set-locale-properties
@@ -30,18 +31,12 @@ jobs:
           paths:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum  "app/build.gradle.kts" }}
-
-  test:
-    executor: android
-    steps:
-      - checkout
-      - set-locale-properties
       - run:
           neme: gem install bundler
           command: sudo gem install bundler:2.4.12
       - run:
           name: bundle install
-          # Gemfileのパスを指定してからbundle installを実行する
+          # Specify Gemfile path and then run bundle install
           command: |
             bundle config set --local path 'vendor/bundle'
             bundle install
@@ -67,17 +62,7 @@ jobs:
 workflows:
   test:
     jobs:
-      - dependencies
-      - test:
-          context: slack-secrets
-          requires:
-            - dependencies
+      - build-and-test
 
 # ■ memo ■
-# チェックコマンド： circleci config validate
-#
-# ■ 特に参考にしたサイト ■
-# Android プロジェクトの継続的インテグレーション
-# https://circleci.com/ja/blog/building-android-on-circleci/
-# 3年の運用で編み出した CircleCI 超設計大全
-# https://qiita.com/dodonki1223/items/98dbdac6f31f9b486ecf
+# check command： circleci config validate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ commands:
 jobs:
   build-and-test:
     executor: android
-    context: slack-secrets
     steps:
       - checkout
       - set-locale-properties
@@ -62,7 +61,8 @@ jobs:
 workflows:
   test:
     jobs:
-      - build-and-test
+      - build-and-test:
+          context: slack-secrets
 
 # ■ memo ■
 # check command： circleci config validate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,7 @@ jobs:
           # Gemfileのパスを指定してからbundle installを実行する
           command: |
             bundle config set --local path 'vendor/bundle'
-            bundle install
-            
+            bundle install --path vendor/bundle
 
       - run:
           name: ktlint-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           # Gemfileのパスを指定してからbundle installを実行する
           command: |
             bundle config set --local path 'vendor/bundle'
-            bundle install --path vendor/bundle
+            bundle install
       - run:
           name: ktlint-check
           command: ./gradlew --continue ktlintCheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,24 +3,32 @@ version: 2.1
 orbs:
   slack: circleci/slack@4.12.5
 jobs:
-  build-and-test:
+  dependencies:
     docker:
       - image: cimg/android:2023.12
     steps:
       - checkout
+
       - run:
           name: set local.properties
           command: |
-              LOCAL_PROPERTIES_PATH=./local.properties
-              echo "apiKey=$.Environment.DEBUG_AD_APPLICATION_ID" >> $LOCAL_PROPERTIES_PATH
+            LOCAL_PROPERTIES_PATH=./local.properties
+            echo "apiKey=$.Environment.DEBUG_AD_APPLICATION_ID" >> $LOCAL_PROPERTIES_PATH
 
       - restore_cache:
           key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum  "app/build.gradle.kts" }}
+
       - run: ./gradlew androidDependencies
+
       - save_cache:
           paths:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum  "app/build.gradle.kts" }}
+
+  build-and-test:
+    docker:
+      - image: cimg/android:2023.12
+    steps:
 
       - run:
           command: sudo gem install bundler:2.4.12
@@ -55,8 +63,11 @@ jobs:
 workflows:
   test:
     jobs:
+      - dependencies
       - build-and-test:
           context: slack-secrets
+          requires:
+            - dependencies
 
 # ■ memo ■
 # チェックコマンド： circleci config validate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,17 +8,24 @@ executors:
     docker:
       - image: cimg/android:2023.12
 
+commands:
+  set-locale-properties:
+    steps:
+      - run:
+          name: set local.properties
+          command: |
+            LOCAL_PROPERTIES_PATH=./local.properties
+            echo "apiKey=$.Environment.DEBUG_AD_APPLICATION_ID" >> $LOCAL_PROPERTIES_PATH
+
 jobs:
   dependencies:
     executor: android
     steps:
       - checkout
-
+      - set-locale-properties
       - restore_cache:
           key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum  "app/build.gradle.kts" }}
-
       - run: ./gradlew androidDependencies
-
       - save_cache:
           paths:
             - ~/.gradle
@@ -28,44 +35,31 @@ jobs:
     executor: android
     steps:
       - checkout
-
-      - run:
-          name: set local.properties
-          command: |
-            LOCAL_PROPERTIES_PATH=./local.properties
-            echo "apiKey=$.Environment.DEBUG_AD_APPLICATION_ID" >> $LOCAL_PROPERTIES_PATH
-
+      - set-locale-properties
       - run:
           neme: gem install bundler
           command: sudo gem install bundler:2.4.12
-
       - run:
           name: bundle install
           # Gemfileのパスを指定してからbundle installを実行する
           command: |
             bundle config set --local path 'vendor/bundle'
             bundle install --path vendor/bundle
-
       - run:
           name: ktlint-check
           command: ./gradlew --continue ktlintCheck
-
       - run:
           name: test
           command: ./gradlew testProdDebug --stacktrace
-
       - run:
           name: jacoco-report
           command: ./gradlew jacocoTestReport
-
       - run:
           name: run-danger-file
           command: bundle exec danger --verbose
-
       - slack/notify:
           event: fail
           template: basic_fail_1
-
       - slack/notify:
           event: pass
           template: basic_success_1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,12 +14,6 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: set local.properties
-          command: |
-            LOCAL_PROPERTIES_PATH=./local.properties
-            echo "apiKey=$.Environment.DEBUG_AD_APPLICATION_ID" >> $LOCAL_PROPERTIES_PATH
-
       - restore_cache:
           key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum  "app/build.gradle.kts" }}
 
@@ -34,6 +28,12 @@ jobs:
     executor: android
     steps:
       - checkout
+
+      - run:
+          name: set local.properties
+          command: |
+            LOCAL_PROPERTIES_PATH=./local.properties
+            echo "apiKey=$.Environment.DEBUG_AD_APPLICATION_ID" >> $LOCAL_PROPERTIES_PATH
 
       - run:
           neme: gem install bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,15 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.12.5
-jobs:
-  dependencies:
+
+executors:
+  android:
     docker:
       - image: cimg/android:2023.12
+
+jobs:
+  dependencies:
+    executor: android
     steps:
       - checkout
 
@@ -26,9 +31,9 @@ jobs:
           key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum  "app/build.gradle.kts" }}
 
   test:
-    docker:
-      - image: cimg/android:2023.12
+    executor: android
     steps:
+      - checkout
 
       - run:
           neme: gem install bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum  "app/build.gradle.kts" }}
 
-  build-and-test:
+  test:
     docker:
       - image: cimg/android:2023.12
     steps:
@@ -64,7 +64,7 @@ workflows:
   test:
     jobs:
       - dependencies
-      - build-and-test:
+      - test:
           context: slack-secrets
           requires:
             - dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,16 @@ jobs:
     steps:
 
       - run:
+          neme: gem install bundler
           command: sudo gem install bundler:2.4.12
 
       - run:
-          command: bundle install
+          name: bundle install
+          # Gemfileのパスを指定してからbundle installを実行する
+          command: |
+            bundle config set --local path 'vendor/bundle'
+            bundle install
+            
 
       - run:
           name: ktlint-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: sudo gem install bundler:2.4.12
 
       - run:
-          command: bundle install --path vendor/bundle
+          command: bundle install
 
       - run:
           name: ktlint-check


### PR DESCRIPTION
## Reference
- [circle ci Blog - Continuous integration for Android projects](https://circleci.com/blog/building-android-on-circleci/)
  - Android プロジェクトの継続的インテグレーションについて雰囲気がわかる
- [circleci ver2.1の新機能`executor`と`commands`を使ってconfigファイルをスッキリさせるMEMO](https://madogiwa0124.hatenablog.com/entry/2020/07/04/214443)
  - executorとcommandの説明がわかりやすかった
- [CircleCI の設定](https://circleci.com/docs/ja/configuration-reference/) 
  - すごい量ある...(とりあえずわからないキーワードとかあったら見にいくのが良さそう) 
- [DroidKaigi conference-app-2020](https://github.com/DroidKaigi/conference-app-2020/blob/master/.circleci/config.yml)
  - DroidKaigiで過去に使用されたconfigファイルだからかなり参考になる

## Memo
- executorとかcommandsあるといろんな箇所にごちゃごちゃ書かなくていい
- jobsがbuild-and-testで、dependenciesとtesに分けたがSign up environmentに１分とかかかることもあって、並列だから分ける意味ないよなあと思って戻した（なんか別れている方がかっこいいと思っただけ...）
