### PR TITLE
CircleCi でMockのビルドができるようにする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,11 @@ jobs:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum  "app/build.gradle.kts" }}
       - run:
-          neme: gem install bundler
-          command: sudo gem install bundler:2.4.12
-      - run:
           name: build mock
           command: ./gradlew compileMockDebugSource
+      - run:
+          neme: gem install bundler
+          command: sudo gem install bundler:2.4.12
       - run:
           name: bundle install
           # Specify Gemfile path and then run bundle install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,9 @@ jobs:
           neme: gem install bundler
           command: sudo gem install bundler:2.4.12
       - run:
+          name: build mock
+          command: ./gradlew compileMockDebugSource
+      - run:
           name: bundle install
           # Specify Gemfile path and then run bundle install
           command: |

--- a/core/data/src/mock/java/ksnd/hiraganaconverter/core/data/repository/MockConvertRepository.kt
+++ b/core/data/src/mock/java/ksnd/hiraganaconverter/core/data/repository/MockConvertRepository.kt
@@ -8,7 +8,7 @@ import ksnd.hiraganaconverter.core.model.ui.HiraKanaType
 import retrofit2.Response
 import javax.inject.Inject
 
-class MockConvertRepository @Inject constructor() : Convertepository {
+class MockConvertRepository @Inject constructor() : ConvertRepository {
     override suspend fun requestConvert(
         sentence: String,
         type: String,

--- a/core/data/src/mock/java/ksnd/hiraganaconverter/core/data/repository/MockConvertRepository.kt
+++ b/core/data/src/mock/java/ksnd/hiraganaconverter/core/data/repository/MockConvertRepository.kt
@@ -8,7 +8,7 @@ import ksnd.hiraganaconverter.core.model.ui.HiraKanaType
 import retrofit2.Response
 import javax.inject.Inject
 
-class MockConvertRepository @Inject constructor() : ConvertRepository {
+class MockConvertRepository @Inject constructor() : Convertepository {
     override suspend fun requestConvert(
         sentence: String,
         type: String,


### PR DESCRIPTION
## Issue
- #402 

## Overview
- Mockのコードが壊れていることに気がつけるようにするために追加する

## Ref
- [Github ActionsとCircleCIの組み合わせが最高という話【後編】](https://qiita.com/dosukoi_android/items/f84907d60c749103bb16)