### PR TITLE
[CircleCI] build-mockを並列化

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ jobs:
           command: ./gradlew --continue ktlintCheck
       - run:
           name: test
+          parallelism: 4
           command: ./gradlew testProdDebug --stacktrace
       - run:
           name: jacoco-report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,28 +17,31 @@ commands:
             LOCAL_PROPERTIES_PATH=./local.properties
             echo "apiKey=$.Environment.DEBUG_AD_APPLICATION_ID" >> $LOCAL_PROPERTIES_PATH
 
-jobs:
-  build-and-test:
-    executor: android
+  restore-and-save-gradle-cache:
     steps:
-      - checkout
-      - set-locale-properties
       - restore_cache:
           key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum  "app/build.gradle.kts" }}
-      - run: ./gradlew androidDependencies
+      - run:
+          name: Download dependencies
+          command: ./gradlew androidDependencies
       - save_cache:
           paths:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum  "app/build.gradle.kts" }}
-      - run:
-          name: build mock
-          command: ./gradlew compileMockDebugSource
+
+jobs:
+  build-and-test-prod:
+    executor: android
+    steps:
+      - checkout
+      - set-locale-properties
+      - restore-and-save-gradle-cache
       - run:
           neme: gem install bundler
           command: sudo gem install bundler:2.4.12
       - run:
-          name: bundle install
           # Specify Gemfile path and then run bundle install
+          name: bundle install
           command: |
             bundle config set --local path 'vendor/bundle'
             bundle install
@@ -65,26 +68,27 @@ jobs:
       - slack/notify:
           event: pass
           template: basic_success_1
-#  deploy:
-#    executor: android
-#    steps:
-#      - checkout
-#      - set-locale-properties
-#      - run:
-#          name: build release
-#          command: ./gradlew assembleProdRelease
+
+  build-mock:
+    executor: android
+    steps:
+      - checkout
+      - set-locale-properties
+      - restore-and-save-gradle-cache
+      - run:
+          name: build mock
+          command: ./gradlew compileMockDebugSource
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
 
 workflows:
   test:
     jobs:
-      - build-and-test:
+      - build-and-test-prod:
           context: slack-secrets
-#      - deploy:
-#          requires:
-#            - build-and-test
-#          filters:
-#            branches:
-#              only: main
+      - build-mock:
+          context: slack-secrets
 
 # ■ memo ■
 # check command： circleci config validate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ jobs:
           command: ./gradlew --continue ktlintCheck
       - run:
           name: test
-          parallelism: 4
           command: ./gradlew testProdDebug --stacktrace
       - run:
           name: jacoco-report


### PR DESCRIPTION
## Issue
- #402 

## Overview
- build-mockがちょっと時間かかるから並列化するようにした（最小で30秒は早くなってそう）
- aab作成（作りかけ）はartifactsが誰でも見えるから消すことにした（セキュリティとか問題なければaab作成するようにしたい）
- ~testでparallelismを４に設定した~（全く早くならなかったため消した）

## Reference
- https://github.com/DroidKaigi/conference-app-2020/blob/master/.circleci/config.yml


<img width="286" alt="image" src="https://github.com/kosenda/hiragana-converter/assets/60963155/dc1c1701-1f3e-458e-96f0-d3636f9413ac">

