### PR TITLE
Roborazziを使って画面の差分を出せるようにする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
             EOF
             
             # Find all the files ending with _compare.png
-            files_to_add=$(find . -type f path "./build/outputs/roborazzi/compareProdDebug/roborazzi" -name "*_compare.png")
+            files_to_add=$(find . -type f -path "./build/outputs/roborazzi/compareProdDebug/roborazzi" -name "*_compare.png")
             
             # Add compare image
             for file in $files_to_add; do

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,16 +143,13 @@ jobs:
             # Find all the files ending with _compare.png
             files_to_add=$(find . -type f -name "*_compare.png")
             
-            # Check for invalid file names and add only valid ones
+            # Add compare image
             for file in $files_to_add; do
               if [[ "$file" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
-                $base_name=$(basename $file)
+                base_name=$(basename $file)
                 echo "|$base_name|<img src="https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name" width="400">|" > comments
               fi
             done
-            
-            ksnd.hiraganaconverter.view.screen.ConverterScreenTest.converterScreen_dark_actual.png
-
       - run:
           name: test comment
           command: gh pr comment "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments || gh pr comment "$CIRCLE_PULL_REQUEST" -F ./comments
@@ -162,10 +159,6 @@ jobs:
       - aws-s3/sync:
           from: ./app/build/outputs/roborazzi
           to: s3://hiraganaconverter-roborazzi/image
-      - store_artifacts:
-          path: ./app/build/outputs/roborazzi
-      - store_artifacts:
-          path: ./build/outputs/roborazzi/compareProdDebug
       - slack/notify:
           event: fail
           template: basic_fail_1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
             for file in $files_to_add; do
               if [[ "$file" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
                 base_name=$(basename $file)
-                echo "| $base_name | ![img](\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name\?raw=true") |" >> comments
+                echo "| $base_name | ![img](\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name?raw=true\") |" >> comments
               fi
             done
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,6 @@ jobs:
           key: "Roborazzi"
       - store_artifacts:
           path: ./app/build/outputs/roborazzi
-
       - gh/setup:
           token: COMMENT_GITHUB_API_TOKEN
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,7 @@ jobs:
             # Add compare image
             for file in $files_to_add; do
               if [[ "$file" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
+                echo "base name: $(basename $file)"
                 base_name=$(basename $file)
                 echo "| $base_name | <img src=\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name?raw=true\" width=\"600\") |" >> comments
               fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,13 +80,13 @@ jobs:
             cat \<< EOF > comments
             |name|image|
             |---|---|
-            |temp|<img src="./app/build/outputs/roborazzi|ksnd.hiraganaconverter.view.screen.ConverterScreenTest.convertScreen_dark_compare.pmn" width="350">|
+            |temp|<img src="./app/build/outputs/roborazzi|ksnd.hiraganaconverter.view.screen.ConverterScreenTest.convertScreen_dark_compare.png" width="350">|
             EOF
       - run:
           name: test comment
           command: |
             echo $CIRCLE_PULL_REQUEST
-            gh pr comment -F --edit-last ./comments "$CIRCLE_PULL_REQUEST" ||  gh pr comment -F ./comments "$CIRCLE_PULL_REQUEST"
+            gh pr comment 999 -F --edit-last ./comments "$CIRCLE_PULL_REQUEST" ||  gh pr comment 999 -F ./comments "$CIRCLE_PULL_REQUEST"
       - run:
           name: jacoco-report
           command: ./gradlew jacocoTestReport

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
             )
             # ◼ Get an installation access token
             echo Get an installation access token
-            token=$(
+            access_token=$(
               echo $(
                 curl -s -X POST \
                 -H "Authorization: Bearer ${jwt}" \
@@ -120,7 +120,7 @@ jobs:
             )
             # ◼ gh auth login
             echo gh auth login
-            $(token) | gh auth login --with-token
+            $(access_token) | gh auth login --with-token
       - run:
           name: create comments
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
     steps:
       - checkout
       - gh/setup:
-        - token: $DANGER_GITHUB_API_TOKEN
+          token: DANGER_GITHUB_API_TOKEN
       - run:
           name: create comments
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,11 @@ jobs:
           name: test comment
           command: |
             echo $CIRCLE_PULL_REQUEST
-            gh pr comment 2 -F --edit-last ./comments "$CIRCLE_PULL_REQUEST" ||  gh pr comment 2 -F ./comments "$CIRCLE_PULL_REQUEST"
+            gh pr comment 99 -F --edit-last ./comments "$CIRCLE_PULL_REQUEST"
+            if [ $? -ne 0 ]; then
+              echo "test test"
+              gh pr comment 99 -F ./comments "$CIRCLE_PULL_REQUEST"
+            fi
       - run:
           name: jacoco-report
           command: ./gradlew jacocoTestReport

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
             for file in $files_to_add; do
               if [[ "$file" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
                 base_name=$(basename $file)
-                echo "|$base_name|<img src=\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name\" width=\"600\">|" />> comments
+                echo "| $base_name | ![img](\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name\") |" >> comments
               fi
             done
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,38 +74,54 @@ jobs:
       - gh/install
       - run:
           name: gh login
+          # Create GitHub App Token using JWT and pass it with gh auth to login
+          # ref: https://zenn.dev/gorohash/articles/e2c5f6ce50f4e6
           command: |
+            # ◼ create JWT
+            # ◼◼ header
             header=$(echo -n '{"alg":"RS256","typ":"JWT"}' | base64 -w 0)
+            # Current Unix time(Epoch)
             now=$(date "+%s")
+            # Date and time token was issued (issued at) (Set 1 minute before the current time to account for the possibility of the clock being off)
             iat=$((${now} - 60))
+            # Date and time when token expires (Expiration time) (10 minutes later)
             exp=$((${now} + (10 * 60)))
-            github_app_id="$APP_ID" # App ID
-            payload=$(echo -n "{\"iat\":${iat},\"exp\":${exp},\"iss\":${github_app_id}}" | base64 -w 0)
+            # ◼◼ payload
+            # iss: GitHub App ID (issuer)
+            iss="$APP_ID"
+            payload=$(echo -n "{\"iat\":${iat},\"exp\":${exp},\"iss\":${iss}}" | base64 -w 0)
+            # ◼◼ signature
             echo $COMMENT_GITHUB_API_TOKEN | base64 --decode > ./githubapps
-            unsigned_token="${header}.${payload}"
-            signed_token=$(echo -n $(echo -n "${unsigned_token}" | openssl dgst -binary -sha256 -sign "./githubapps" | base64))
+            signature=$(echo -n $(echo -n "${header}.${payload}" | openssl dgst -binary -sha256 -sign "./githubapps" | base64))
             rm ./githubapps
-            jwt="${unsigned_token}.${signed_token}"
-            user_name="kosenda" # githubアカウント
+            # ◼◼ jwt
+            jwt="${header}.${payload}.${signature}"
+            # ◼ Generating an installation access token for a GitHub App
+            user_name="kosenda"
             installation_id=$(
-              curl -s -X GET \
+              curl -s -G \
                 -H "Authorization: Bearer ${jwt}" \
-                -H "Accept: application/vnd.github.v3+json" \
+                -H "Accept: application/vnd.github+json" \
                 "https://api.github.com/app/installations" \
-              | jq -r ".[] | select(.account.login == \"${user_name}\" and .account.type == \"User\") | .id"
-            ) # account_type が Organization の場合は $user_name は OrganizationName にする
-            echo $(
-              curl -s -X POST \
+                | jq -r ".[] | select(.account.login == \"${user_name}\" and .account.type == \"User\") | .id"
+            )
+            # ◼ Get an installation access token
+            token=$(
+              echo $(
+                curl -s -X POST \
                 -H "Authorization: Bearer ${jwt}" \
-                -H "Accept: application/vnd.github.v3+json" \
+                -H "Accept: application/vnd.github+json" \
                 "https://api.github.com/app/installations/${installation_id}/access_tokens" \
-              | jq -r ".token"
-            ) | gh auth login --with-token
+                | jq -r ".token"
+              )
+            )
+            # ◼ gh auth login
+            gh auth login --with-token $token
       - run:
           name: create comments
           command: |
             cat \<< EOF > comments
-            |name|image|
+            |fileName|image|
             |---|---|
             |temp|<img src="./app/build/outputs/roborazzi|ksnd.hiraganaconverter.view.screen.ConverterScreenTest.convertScreen_dark_compare.png" width="350">|
             EOF

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
     executor: android
     steps:
       - checkout
-      - gh/install
+      - gh/setup
       - run:
           name: create comments
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,33 @@ jobs:
       - gh/install
       - run:
           name: gh login
-          command: echo $COMMENT_GITHUB_API_TOKEN | base64 -d | gh auth login --with-token
+          command: |
+            header=$(echo -n '{"alg":"RS256","typ":"JWT"}' | base64 -w 0)
+            now=$(date "+%s")
+            iat=$((${now} - 60))
+            exp=$((${now} + (10 * 60)))
+            github_app_id="$APP_ID" # App ID
+            payload=$(echo -n "{\"iat\":${iat},\"exp\":${exp},\"iss\":${github_app_id}}" | base64 -w 0)
+            echo $COMMENT_GITHUB_API_TOKEN | base64 --decode > ./githubapps
+            unsigned_token="${header}.${payload}"
+            signed_token=$(echo -n $(echo -n "${unsigned_token}" | openssl dgst -binary -sha256 -sign "./githubapps" | base64))
+            rm ./githubapps
+            jwt="${unsigned_token}.${signed_token}"
+            user_name="kosenda" # githubアカウント
+            installation_id=$(
+              curl -s -X GET \
+                -H "Authorization: Bearer ${jwt}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                "https://api.github.com/app/installations" \
+              | jq -r ".[] | select(.account.login == \"${user_name}\" and .account.type == \"User\") | .id"
+            ) # account_type が Organization の場合は $user_name は OrganizationName にする
+            echo $(
+              curl -s -X POST \
+                -H "Authorization: Bearer ${jwt}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                "https://api.github.com/app/installations/${installation_id}/access_tokens" \
+              | jq -r ".token"
+            ) | gh auth login --with-token
       - run:
           name: create comments
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,7 @@ jobs:
           key: "Roborazzi"
       - store_artifacts:
           path: ./app/build/outputs/roborazzi
-      - gh/setup:
-          token: COMMENT_GITHUB_API_TOKEN
+      - gh/setup
       - run:
           name: create comments
           command: |
@@ -83,7 +82,9 @@ jobs:
             EOF
       - run:
           name: test comment
-          command: gh pr comment "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments || gh pr comment "$CIRCLE_PULL_REQUEST" -F ./comments
+          command: |
+            gh auth login--with-token < echo COMMENT_GITHUB_API_TOKEN | base64 -d
+            gh pr comment "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments || gh pr comment "$CIRCLE_PULL_REQUEST" -F ./comments
       - run:
           name: jacoco-report
           command: ./gradlew jacocoTestReport

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
             for file in $files_to_add; do
               if [[ "$file" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
                 base_name=$(basename $file)
-                echo "|$base_name|<img src="https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name" width="400">|" > comments
+                echo "|$base_name|<img src=\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name\" width=\"400\">|" />> comments
               fi
             done
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
           region: AWS_REGION
       - aws-s3/copy:
           arguments: --recursive
-          from: "s3://hiraganaconverter-roborazzi/image/$CIRCLE_BRANCH"
+          from: "s3://hiraganaconverter-roborazzi/image/$BASE_BRANCH_NAME"
           to: ./app/build/outputs/roborazzi
       - run:
           name: compare screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           path: ./app/build/outputs/roborazzi
       - run:
           name: settings environment variables
-          command: echo COMMENT_GITHUB_API_TOKEN | base64 -d >> "$GITHUB_API_ENV"
+          command: echo "$COMMENT_GITHUB_API_TOKEN" | base64 -d >> "$GITHUB_API_ENV"
       - gh/setup:
           token: GITHUB_API_ENV
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,18 @@ jobs:
     executor: android
     steps:
       - checkout
+      - run:
+          name: create comments
+          command: |
+            cat << EOF > comments
+            test!
+            test!!
+            EOF
+      - run:
+          name: test comment
+          command: |
+            echo $CIRCLE_PULL_REQUEST
+            gh pr comment -F ./comments "$CIRCLE_PULL_REQUEST"
       - set-locale-properties
       - restore-and-save-gradle-cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ jobs:
           # ref: https://zenn.dev/gorohash/articles/e2c5f6ce50f4e6
           command: |
             # ◼ create JWT
+            echo create JWT
             # ◼◼ header
             header=$(echo -n '{"alg":"RS256","typ":"JWT"}' | base64 -w 0)
             # Current Unix time(Epoch)
@@ -97,6 +98,7 @@ jobs:
             # ◼◼ jwt
             jwt="${header}.${payload}.${signature}"
             # ◼ Generating an installation access token for a GitHub App
+            echo Generating an installation access token for a GitHub App
             user_name="kosenda"
             installation_id=$(
               curl -s -G \
@@ -106,6 +108,7 @@ jobs:
                 | jq -r ".[] | select(.account.login == \"${user_name}\" and .account.type == \"User\") | .id"
             )
             # ◼ Get an installation access token
+            echo Get an installation access token
             token=$(
               echo $(
                 curl -s -X POST \
@@ -116,7 +119,8 @@ jobs:
               )
             )
             # ◼ gh auth login
-            gh auth login --with-token $token
+            echo gh auth login
+            gh auth login --with-token $(token)
       - run:
           name: create comments
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,11 +86,12 @@ jobs:
           name: test comment
           command: |
             echo $CIRCLE_PULL_REQUEST
-            gh pr comment 99 -F --edit-last ./comments "$CIRCLE_PULL_REQUEST"
-            if [ $? -ne 0 ]; then
-              echo "test test"
-              gh pr comment 99 -F ./comments "$CIRCLE_PULL_REQUEST"
-            fi
+            gh pr comment 99 --edit-last -F ./comments "$CIRCLE_PULL_REQUEST" || gh pr comment 99 -F ./comments "$CIRCLE_PULL_REQUEST"
+#            gh pr comment 99 --edit-last -F ./comments "$CIRCLE_PULL_REQUEST"
+#            if [ $? -ne 0 ]; then
+#              echo "test test"
+#              gh pr comment 99 ./comments -F "$CIRCLE_PULL_REQUEST"
+#            fi
       - run:
           name: jacoco-report
           command: ./gradlew jacocoTestReport

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
               if [[ "$file" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
                 echo "base name: $(basename $file)"
                 base_name=$(basename $file)
-                echo "| $base_name | <img src=\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name?raw=true\" width=\"600\") |" >> comments
+                echo "| $base_name | <img src=\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name\" width=\"600\") |" >> comments
               fi
             done
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,10 +134,20 @@ jobs:
       - run:
           name: create comments
           command: |
+            # Find all the files ending with _compare.png
+            files_to_add=$(find . -type f -name "*_compare.png")
+            
+            # Check for invalid file names and add only valid ones
+            for file in $files_to_add; do
+              if [[ "$file" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
+                echo "fileName: $file"
+              fi
+            done
+            
             cat \<< EOF > comments
             |fileName|image|
             |---|---|
-            |converterScreen_dark_compare.png|<img src="./build/outputs/roborazzi/compareProdDebug/roborazzi/ksnd.hiraganaconverter.view.screen.ConverterScreenTest.converterScreen_dark_compare.png" width="350">|
+            |file|<img src="./build/outputs/roborazzi/compareProdDebug/roborazzi/ksnd.hiraganaconverter.view.screen.ConverterScreenTest.converterScreen_light_compare.png" width="350">|
             EOF
       - run:
           name: test comment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           path: ./app/build/outputs/roborazzi
 
       - gh/setup:
-          token: DANGER_GITHUB_API_TOKEN
+          token: COMMENT_GITHUB_API_TOKEN
       - run:
           name: create comments
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,9 +59,6 @@ jobs:
           name: compare screenshots
           command: ./gradlew compareRoborazziProdDebug --stacktrace
       - run:
-          name: test comment
-          command: gh pr comment "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments || gh pr comment "$CIRCLE_PULL_REQUEST" -F ./comments
-      - run:
           name: jacoco-report
           command: ./gradlew jacocoTestReport
       - run:
@@ -136,6 +133,9 @@ jobs:
             |---|---|
             |temp|<img src="./app/build/outputs/roborazzi|ksnd.hiraganaconverter.view.screen.ConverterScreenTest.convertScreen_dark_compare.png" width="350">|
             EOF
+      - run:
+          name: test comment
+          command: gh pr comment "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments || gh pr comment "$CIRCLE_PULL_REQUEST" -F ./comments
       - run:
           name: create screenshots
           command: ./gradlew recordRoborazziProdDebug --stacktrace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,10 @@ jobs:
       - run:
           name: test comment
           command: |
-            gh pr comment 99 "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments
+            gh pr comment "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments
             if [ $? -ne 0 ]; then
               echo "test test"
-              gh pr comment 99 "$CIRCLE_PULL_REQUEST" -F ./comments
+              gh pr comment "$CIRCLE_PULL_REQUEST" -F ./comments
             fi
       - run:
           name: jacoco-report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
             for file in $files_to_add; do
               if [[ "$file" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
                 base_name=$(basename $file)
-                echo "|$base_name|<img src=\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name\" width=\"400\">|" />> comments
+                echo "|$base_name|<img src=\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name\" width=\"600\">|" />> comments
               fi
             done
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ commands:
 jobs:
   build-and-test-prod:
     executor: android
+    environment:
+      GITHUB_API_ENV: echo "$COMMENT_GITHUB_API_TOKEN" | base64 -d
     steps:
       - checkout
       - set-locale-properties
@@ -71,9 +73,6 @@ jobs:
           key: "Roborazzi"
       - store_artifacts:
           path: ./app/build/outputs/roborazzi
-      - run:
-          name: settings environment variables
-          command: echo "$COMMENT_GITHUB_API_TOKEN" | base64 -d >> "$GITHUB_API_ENV"
       - gh/setup:
           token: GITHUB_API_ENV
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
             )
             # ◼ gh auth login
             echo gh auth login
-            gh auth login --with-token $(token)
+            $(token) | gh auth login --with-token
       - run:
           name: create comments
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,7 @@ jobs:
           key: "Roborazzi"
       - store_artifacts:
           path: ./app/build/outputs/roborazzi
-      - gh/setup:
-          token: GITHUB_API_ENV
+      - gh/setup
       - run:
           name: create comments
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ jobs:
           aws_secret_access_key: AWS_SECRET_ACCESS_KEY
           region: AWS_REGION
       - aws-s3/copy:
+          arguments: --recursive
           from: s3://hiraganaconverter-roborazzi/image
           to: ./app/build/outputs/roborazzi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,8 @@ jobs:
           paths:
             - ./app/build/outputs/roborazzi
           key: "Roborazzi"
+      - store_artifacts:
+          path: ./app/build/outputs/roborazzi
       - run:
           name: jacoco-report
           command: ./gradlew jacocoTestReport

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,8 +85,7 @@ jobs:
       - run:
           name: test comment
           command: |
-            echo $CIRCLE_PULL_REQUEST
-            gh pr comment 99 "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments ||gh pr comment 99 "$CIRCLE_PULL_REQUEST" -F ./comments
+            gh pr comment 99 "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments || gh pr comment 99 "$CIRCLE_PULL_REQUEST" -F ./comments
 #            gh pr comment 99 --edit-last -F ./comments "$CIRCLE_PULL_REQUEST"
 #            if [ $? -ne 0 ]; then
 #              echo "test test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,8 @@ jobs:
     executor: android
     steps:
       - checkout
-      - gh/setup
+      - gh/setup:
+        - token: $DANGER_GITHUB_API_TOKEN
       - run:
           name: create comments
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
               if [[ "$file" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
                 echo "base name: $(basename $file)"
                 base_name=$(basename $file)
-                echo "| $base_name | <img src=\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name\" width=\"600\") |" >> comments
+                echo "| $base_name | <img src=\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name\" width=\"600\"> |" >> comments
               fi
             done
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
       - run:
           name: create comments
           command: |
-            cat << EOF > comments
+            cat \<< EOF > comments
             test!
             test!!
             EOF

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,12 +84,7 @@ jobs:
             EOF
       - run:
           name: test comment
-          command: |
-            gh pr comment "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments
-            if [ $? -ne 0 ]; then
-              echo "test test"
-              gh pr comment "$CIRCLE_PULL_REQUEST" -F ./comments
-            fi
+          command: gh pr comment "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments || gh pr comment "$CIRCLE_PULL_REQUEST" -F ./comments
       - run:
           name: jacoco-report
           command: ./gradlew jacocoTestReport

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   slack: circleci/slack@4.12.5
   gh: circleci/github-cli@2.3.0
+  aws-cli: circleci/aws-cli@4.0
   aws-s3: circleci/aws-s3@4.0.0
 
 executors:
@@ -142,7 +143,7 @@ jobs:
       - run:
           name: create screenshots
           command: ./gradlew recordRoborazziProdDebug --stacktrace
-      - aws-cli/setup:
+      - aws-s3/setup:
           aws_access_key_id: AWS_ACCESS_KEY_ID
           aws_secret_access_key: AWS_SECRET_ACCESS_KEY
           region: AWS_REGION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,25 +52,32 @@ jobs:
       - run:
           name: test
           command: ./gradlew testProdDebug --stacktrace
-      - restore_cache:
-          key: "Roborazzi"
+
+      # TODO 何かしらの方法で過去に取得したスクリーンショットを取得する
+
       - run:
           name: compare screenshots
           command: ./gradlew compareRoborazziProdDebug --stacktrace
       - run:
-          name: move screenshots files
-          command: |
-            mkdir -p ./build/outputs/roborazzi/compareProdDebug
-            mv ./app/build/outputs/roborazzi ./build/outputs/roborazzi/compareProdDebug
+          name: test comment
+          command: gh pr comment "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments || gh pr comment "$CIRCLE_PULL_REQUEST" -F ./comments
       - run:
-          name: create screenshots
-          command: ./gradlew recordRoborazziProdDebug --stacktrace
-      - save_cache:
-          paths:
-            - ./app/build/outputs/roborazzi
-          key: "Roborazzi"
+          name: jacoco-report
+          command: ./gradlew jacocoTestReport
+      - run:
+          name: jacoco-report to zip
+          command: zip -r jacocoTestReport.zip ./build/reports/jacoco/jacocoTestReport/html
       - store_artifacts:
-          path: ./app/build/outputs/roborazzi
+          path: jacocoTestReport.zip
+      - run:
+          name: run-danger-file
+          command: bundle exec danger --verbose
+
+#      - run:
+#          name: move screenshots files
+#          command: |
+#            mkdir -p ./build/outputs/roborazzi/compareProdDebug
+#            mv ./app/build/outputs/roborazzi ./build/outputs/roborazzi/compareProdDebug
       - gh/install
       - run:
           name: gh login
@@ -120,7 +127,7 @@ jobs:
             )
             # ◼ gh auth login
             echo gh auth login
-            $(access_token) | gh auth login --with-token
+            echo "$access_token" | gh auth login --with-token
       - run:
           name: create comments
           command: |
@@ -130,19 +137,13 @@ jobs:
             |temp|<img src="./app/build/outputs/roborazzi|ksnd.hiraganaconverter.view.screen.ConverterScreenTest.convertScreen_dark_compare.png" width="350">|
             EOF
       - run:
-          name: test comment
-          command: gh pr comment "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments || gh pr comment "$CIRCLE_PULL_REQUEST" -F ./comments
-      - run:
-          name: jacoco-report
-          command: ./gradlew jacocoTestReport
-      - run:
-          name: jacoco-report to zip
-          command: zip -r jacocoTestReport.zip ./build/reports/jacoco/jacocoTestReport/html
-      - store_artifacts:
-          path: jacocoTestReport.zip
-      - run:
-          name: run-danger-file
-          command: bundle exec danger --verbose
+          name: create screenshots
+          command: ./gradlew recordRoborazziProdDebug --stacktrace
+#          TODO 何かしらの方法でスクリーンショットを保存するz1
+#      - save_cache:
+#          paths:
+#            - ./app/build/outputs/roborazzi
+#          key: "Roborazzi"
       - slack/notify:
           event: fail
           template: basic_fail_1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           name: test comment
           command: |
             echo $CIRCLE_PULL_REQUEST
-            gh pr comment 999 -F --edit-last ./comments "$CIRCLE_PULL_REQUEST" ||  gh pr comment 999 -F ./comments "$CIRCLE_PULL_REQUEST"
+            gh pr comment 2 -F --edit-last ./comments "$CIRCLE_PULL_REQUEST" ||  gh pr comment 2 -F ./comments "$CIRCLE_PULL_REQUEST"
       - run:
           name: jacoco-report
           command: ./gradlew jacocoTestReport

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
             EOF
             
             # Find all the files ending with _compare.png
-            files_to_add=$(find . -type f -name "*_compare.png")
+            files_to_add=$(find . -type f path "./build/outputs/roborazzi/compareProdDebug/roborazzi" -name "*_compare.png")
             
             # Add compare image
             for file in $files_to_add; do

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,8 @@ jobs:
               if [[ "$file" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
                 echo "base name: $(basename $file)"
                 base_name=$(basename $file)
-                echo "| $base_name | <img src=\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name\" width=\"600\"> |" >> comments
+                name=$(echo $base_name | rev | cut -d. -f-2 | rev )
+                echo "| $name | <img src=\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name\" width=\"600\"> |" >> comments
               fi
             done
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,8 @@ jobs:
           command: ./gradlew testProdDebug --stacktrace
 
       # TODO 何かしらの方法で過去に取得したスクリーンショットを取得する
+      - restore_cache:
+          key: "Roborazzi"
 
       - run:
           name: compare screenshots
@@ -70,11 +72,11 @@ jobs:
           name: run-danger-file
           command: bundle exec danger --verbose
 
-#      - run:
-#          name: move screenshots files
-#          command: |
-#            mkdir -p ./build/outputs/roborazzi/compareProdDebug
-#            mv ./app/build/outputs/roborazzi ./build/outputs/roborazzi/compareProdDebug
+      - run:
+          name: move screenshots files
+          command: |
+            mkdir -p ./build/outputs/roborazzi/compareProdDebug
+            mv ./app/build/outputs/roborazzi ./build/outputs/roborazzi/compareProdDebug
       - gh/install
       - run:
           name: gh login
@@ -131,7 +133,7 @@ jobs:
             cat \<< EOF > comments
             |fileName|image|
             |---|---|
-            |temp|<img src="./app/build/outputs/roborazzi|ksnd.hiraganaconverter.view.screen.ConverterScreenTest.convertScreen_dark_compare.png" width="350">|
+            |./build/outputs/roborazzi/compareProdDebug/ksnd.hiraganaconverter.view.screen.ConverterScreenTest.converterScreen_dark_compare.png|<img src="./build/outputs/roborazzi/compareProdDebug/ksnd.hiraganaconverter.view.screen.ConverterScreenTest.converterScreen_dark_compare.png" width="350">|
             EOF
       - run:
           name: test comment
@@ -139,11 +141,10 @@ jobs:
       - run:
           name: create screenshots
           command: ./gradlew recordRoborazziProdDebug --stacktrace
-#          TODO 何かしらの方法でスクリーンショットを保存するz1
-#      - save_cache:
-#          paths:
-#            - ./app/build/outputs/roborazzi
-#          key: "Roborazzi"
+      - store_artifacts:
+          path: ./app/build/outputs/roborazzi
+      - store_artifacts:
+          path: ./build/outputs/roborazzi/compareProdDebug
       - slack/notify:
           event: fail
           template: basic_fail_1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.12.5
-  github-cli: circleci/github-cli@2.3.0
+  gh: circleci/github-cli@2.3.0
 
 executors:
   android:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,22 @@ jobs:
           key: "Roborazzi"
       - store_artifacts:
           path: ./app/build/outputs/roborazzi
+
+      - gh/setup:
+          token: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: create comments
+          command: |
+            cat \<< EOF > comments
+            |name|image|
+            |---|---|
+            |temp|<img src="./app/build/outputs/roborazzi|ksnd.hiraganaconverter.view.screen.ConverterScreenTest.convertScreen_dark_compare.pmn" width="350">|
+            EOF
+      - run:
+          name: test comment
+          command: |
+            echo $CIRCLE_PULL_REQUEST
+            gh pr comment -F ./comments "$CIRCLE_PULL_REQUEST"
       - run:
           name: jacoco-report
           command: ./gradlew jacocoTestReport
@@ -93,21 +109,6 @@ jobs:
     executor: android
     steps:
       - checkout
-      - gh/setup:
-          token: DANGER_GITHUB_API_TOKEN
-      - run:
-          name: create comments
-          command: |
-            cat \<< EOF > comments
-            |name|image|
-            |---|---|
-            |temp|<img src="./app/build/outputs/roborazzi|ksnd.hiraganaconverter.view.screen.ConverterScreenTest.convertScreen_dark_compare.pmn" width="350">|
-            EOF
-      - run:
-          name: test comment
-          command: |
-            echo $CIRCLE_PULL_REQUEST
-            gh pr comment -F ./comments "$CIRCLE_PULL_REQUEST"
       - set-locale-properties
       - restore-and-save-gradle-cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,21 +134,25 @@ jobs:
       - run:
           name: create comments
           command: |
+            # create comments
+            cat \<< EOF > comments
+            |fileName|image|
+            |---|---|
+            EOF
+            
             # Find all the files ending with _compare.png
             files_to_add=$(find . -type f -name "*_compare.png")
             
             # Check for invalid file names and add only valid ones
             for file in $files_to_add; do
               if [[ "$file" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
-                echo "fileName: $file"
+                $base_name=$(basename $file)
+                echo "|$base_name|<img src="https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name" width="400">|" > comments
               fi
             done
             
-            cat \<< EOF > comments
-            |fileName|image|
-            |---|---|
-            |file|<img src="./build/outputs/roborazzi/compareProdDebug/roborazzi/ksnd.hiraganaconverter.view.screen.ConverterScreenTest.converterScreen_light_compare.png" width="350">|
-            EOF
+            ksnd.hiraganaconverter.view.screen.ConverterScreenTest.converterScreen_dark_actual.png
+
       - run:
           name: test comment
           command: gh pr comment "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments || gh pr comment "$CIRCLE_PULL_REQUEST" -F ./comments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,8 @@ jobs:
           aws_secret_access_key: AWS_SECRET_ACCESS_KEY
           region: AWS_REGION
       - aws-s3/copy:
-          from: ./app/build/outputs/roborazzi
-          to: s3://hiraganaconverter-roborazzi/image
+          from: s3://hiraganaconverter-roborazzi/image
+          to: ./app/build/outputs/roborazzi
       - run:
           name: compare screenshots
           command: ./gradlew compareRoborazziProdDebug --stacktrace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   slack: circleci/slack@4.12.5
   gh: circleci/github-cli@2.3.0
+  aws-s3: circleci/aws-s3@4.0.0
 
 executors:
   android:
@@ -141,6 +142,13 @@ jobs:
       - run:
           name: create screenshots
           command: ./gradlew recordRoborazziProdDebug --stacktrace
+      - aws-cli/setup:
+          aws_access_key_id: AWS_ACCESS_KEY_ID
+          aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+          region: AWS_REGION
+      - aws-s3/sync:
+          from: ./app/build/outputs/roborazzi
+          to: s3://hiraganaconverter-roborazzi/image
       - store_artifacts:
           path: ./app/build/outputs/roborazzi
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
       - run:
           name: create screenshots
           command: ./gradlew recordRoborazziProdDebug --stacktrace
-      - aws-s3/setup:
+      - aws-cli/setup:
           aws_access_key_id: AWS_ACCESS_KEY_ID
           aws_secret_access_key: AWS_SECRET_ACCESS_KEY
           region: AWS_REGION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - gh/install
       - run:
           name: gh login
-          command: gh auth login --with-token \<< echo $COMMENT_GITHUB_API_TOKEN | base64 -d
+          command: echo $COMMENT_GITHUB_API_TOKEN | base64 -d | gh auth login --with-token
       - run:
           name: create comments
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,11 +54,13 @@ jobs:
       - run:
           name: test
           command: ./gradlew testProdDebug --stacktrace
-
-      # TODO 何かしらの方法で過去に取得したスクリーンショットを取得する
-      - restore_cache:
-          key: "Roborazzi"
-
+      - aws-cli/setup:
+          aws_access_key_id: AWS_ACCESS_KEY_ID
+          aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+          region: AWS_REGION
+      - aws-s3/copy:
+          from: ./app/build/outputs/roborazzi
+          to: s3://hiraganaconverter-roborazzi/image
       - run:
           name: compare screenshots
           command: ./gradlew compareRoborazziProdDebug --stacktrace
@@ -73,7 +75,6 @@ jobs:
       - run:
           name: run-danger-file
           command: bundle exec danger --verbose
-
       - run:
           name: move screenshots files
           command: |
@@ -135,7 +136,7 @@ jobs:
             cat \<< EOF > comments
             |fileName|image|
             |---|---|
-            |./build/outputs/roborazzi/compareProdDebug/ksnd.hiraganaconverter.view.screen.ConverterScreenTest.converterScreen_dark_compare.png|<img src="./build/outputs/roborazzi/compareProdDebug/ksnd.hiraganaconverter.view.screen.ConverterScreenTest.converterScreen_dark_compare.png" width="350">|
+            |converterScreen_dark_compare.png|<img src="./build/outputs/roborazzi/compareProdDebug/roborazzi/ksnd.hiraganaconverter.view.screen.ConverterScreenTest.converterScreen_dark_compare.png" width="350">|
             EOF
       - run:
           name: test comment
@@ -143,10 +144,6 @@ jobs:
       - run:
           name: create screenshots
           command: ./gradlew recordRoborazziProdDebug --stacktrace
-      - aws-cli/setup:
-          aws_access_key_id: AWS_ACCESS_KEY_ID
-          aws_secret_access_key: AWS_SECRET_ACCESS_KEY
-          region: AWS_REGION
       - aws-s3/sync:
           from: ./app/build/outputs/roborazzi
           to: s3://hiraganaconverter-roborazzi/image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
             for file in $files_to_add; do
               if [[ "$file" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
                 base_name=$(basename $file)
-                echo "| $base_name | ![img](\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name?raw=true\") |" >> comments
+                echo "| $base_name | <img src=\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name?raw=true\" width=\"600\") |" >> comments
               fi
             done
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,11 @@ jobs:
           key: "Roborazzi"
       - store_artifacts:
           path: ./app/build/outputs/roborazzi
-      - gh/setup
+      - run:
+          name: settings environment variables
+          command: echo COMMENT_GITHUB_API_TOKEN | base64 -d >> "$GITHUB_API_ENV"
+      - gh/setup:
+          token: GITHUB_API_ENV
       - run:
           name: create comments
           command: |
@@ -82,9 +86,7 @@ jobs:
             EOF
       - run:
           name: test comment
-          command: |
-            gh auth login--with-token < echo COMMENT_GITHUB_API_TOKEN | base64 -d
-            gh pr comment "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments || gh pr comment "$CIRCLE_PULL_REQUEST" -F ./comments
+          command: gh pr comment "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments || gh pr comment "$CIRCLE_PULL_REQUEST" -F ./comments
       - run:
           name: jacoco-report
           command: ./gradlew jacocoTestReport

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,6 @@ commands:
 jobs:
   build-and-test-prod:
     executor: android
-    environment:
-      GITHUB_API_ENV: echo "$COMMENT_GITHUB_API_TOKEN" | base64 -d
     steps:
       - checkout
       - set-locale-properties
@@ -73,7 +71,10 @@ jobs:
           key: "Roborazzi"
       - store_artifacts:
           path: ./app/build/outputs/roborazzi
-      - gh/setup
+      - gh/install
+      - run:
+          name: gh login
+          command: gh auth login --with-token \<< echo $COMMENT_GITHUB_API_TOKEN | base64 -d
       - run:
           name: create comments
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
             for file in $files_to_add; do
               if [[ "$file" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
                 base_name=$(basename $file)
-                echo "| $base_name | ![img](\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name\") |" >> comments
+                echo "| $base_name | ![img](\"https://hiraganaconverter-roborazzi.s3.ap-northeast-1.amazonaws.com/image/$base_name\?raw=true") |" >> comments
               fi
             done
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ commands:
           paths:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum  "app/build.gradle.kts" }}
+
   set-github-access-token:
     steps:
       - run:
@@ -81,7 +82,7 @@ commands:
             )
             
             # ◼ set github access token
-            echo "export GITHUB_ACCESS_TOKEN='$(access_token)'" >> $BASH_ENV
+            echo "export GITHUB_ACCESS_TOKEN='$access_token'" >> $BASH_ENV
 
 jobs:
   build-and-test-prod:
@@ -201,6 +202,10 @@ jobs:
       - run:
           name: create screenshots
           command: ./gradlew recordRoborazziMockDebug --stacktrace
+      - aws-cli/setup:
+          aws_access_key_id: AWS_ACCESS_KEY_ID
+          aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+          region: AWS_REGION
       - aws-s3/sync:
           from: ./app/build/outputs/roborazzi
           to: s3://hiraganaconverter-roborazzi/image/$CIRCLE_BRANCH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,12 +85,11 @@ jobs:
       - run:
           name: test comment
           command: |
-            gh pr comment 99 "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments || gh pr comment 99 "$CIRCLE_PULL_REQUEST" -F ./comments
-#            gh pr comment 99 --edit-last -F ./comments "$CIRCLE_PULL_REQUEST"
-#            if [ $? -ne 0 ]; then
-#              echo "test test"
-#              gh pr comment 99 ./comments -F "$CIRCLE_PULL_REQUEST"
-#            fi
+            gh pr comment 99 "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments
+            if [ $? -ne 0 ]; then
+              echo "test test"
+              gh pr comment 99 "$CIRCLE_PULL_REQUEST" -F ./comments
+            fi
       - run:
           name: jacoco-report
           command: ./gradlew jacocoTestReport

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           name: test comment
           command: |
             echo $CIRCLE_PULL_REQUEST
-            gh pr comment -F ./comments "$CIRCLE_PULL_REQUEST"
+            gh pr comment -F --edit-last ./comments "$CIRCLE_PULL_REQUEST" ||  gh pr comment -F ./comments "$CIRCLE_PULL_REQUEST"
       - run:
           name: jacoco-report
           command: ./gradlew jacocoTestReport

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,9 +100,8 @@ jobs:
           command: |
             # ◼ get base branch name
             pr=$(echo https://api.github.com/repos/${CIRCLE_PULL_REQUEST:19} | sed "s/\/pull\//\/pulls\//")
-            echo "PR=${pr}"
             base=$(curl -s -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" $pr | jq '.base.ref')
-            echo "BASE_BRANCH_NAME=${base}"
+            echo "base branch name: $base"
             echo "export BASE_BRANCH_NAME=${base}" >> $BASH_ENV
       - set-locale-properties
       - restore-and-save-gradle-cache
@@ -222,6 +221,5 @@ workflows:
               only:
                 - main
                 - develop
-                - feature/circleci-roborazzi
 # ■ memo ■
 # check command： circleci config validate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
             EOF
             
             # Find all the files ending with _compare.png
-            files_to_add=$(find . -type f -path "./build/outputs/roborazzi/compareProdDebug/roborazzi" -name "*_compare.png")
+            files_to_add=$(find . -type f -path "./build/outputs/roborazzi/compareProdDebug/roborazzi/*" -name "*_compare.png")
             
             # Add compare image
             for file in $files_to_add; do

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
     executor: android
     steps:
       - checkout
+      - gh/install
       - run:
           name: create comments
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.12.5
+  github-cli: circleci/github-cli@2.3.0
 
 executors:
   android:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,8 +99,9 @@ jobs:
           name: create comments
           command: |
             cat \<< EOF > comments
-            test!
-            test!!
+            |name|image|
+            |---|---|
+            |temp|<img src="./app/build/outputs/roborazzi|ksnd.hiraganaconverter.view.screen.ConverterScreenTest.convertScreen_dark_compare.pmn" width="350">|
             EOF
       - run:
           name: test comment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,8 +127,7 @@ jobs:
           region: AWS_REGION
       - aws-s3/copy:
           arguments: --recursive
-          ## TODO: マージ先のブランチ名から持ってくる
-          from: s3://hiraganaconverter-roborazzi/image
+          from: "s3://hiraganaconverter-roborazzi/image/$CIRCLE_BRANCH"
           to: ./app/build/outputs/roborazzi
       - run:
           name: compare screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           name: test comment
           command: |
             echo $CIRCLE_PULL_REQUEST
-            gh pr comment 99 --edit-last -F ./comments "$CIRCLE_PULL_REQUEST" || gh pr comment 99 -F ./comments "$CIRCLE_PULL_REQUEST"
+            gh pr comment 99 "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments ||gh pr comment 99 "$CIRCLE_PULL_REQUEST" -F ./comments
 #            gh pr comment 99 --edit-last -F ./comments "$CIRCLE_PULL_REQUEST"
 #            if [ $? -ne 0 ]; then
 #              echo "test test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,59 +31,10 @@ commands:
           paths:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum  "app/build.gradle.kts" }}
-
-jobs:
-  build-and-test-prod:
-    executor: android
+  set-github-access-token:
     steps:
-      - checkout
-      - set-locale-properties
-      - restore-and-save-gradle-cache
       - run:
-          neme: gem install bundler
-          command: sudo gem install bundler:2.4.12
-      - run:
-          # Specify Gemfile path and then run bundle install
-          name: bundle install
-          command: |
-            bundle config set --local path 'vendor/bundle'
-            bundle install
-      - run:
-          name: ktlint-check
-          command: ./gradlew --continue ktlintCheck
-      - run:
-          name: test
-          command: ./gradlew testProdDebug --stacktrace
-      - aws-cli/setup:
-          aws_access_key_id: AWS_ACCESS_KEY_ID
-          aws_secret_access_key: AWS_SECRET_ACCESS_KEY
-          region: AWS_REGION
-      - aws-s3/copy:
-          arguments: --recursive
-          from: s3://hiraganaconverter-roborazzi/image
-          to: ./app/build/outputs/roborazzi
-      - run:
-          name: compare screenshots
-          command: ./gradlew compareRoborazziProdDebug --stacktrace
-      - run:
-          name: jacoco-report
-          command: ./gradlew jacocoTestReport
-      - run:
-          name: jacoco-report to zip
-          command: zip -r jacocoTestReport.zip ./build/reports/jacoco/jacocoTestReport/html
-      - store_artifacts:
-          path: jacocoTestReport.zip
-      - run:
-          name: run-danger-file
-          command: bundle exec danger --verbose
-      - run:
-          name: move screenshots files
-          command: |
-            mkdir -p ./build/outputs/roborazzi/compareProdDebug
-            mv ./app/build/outputs/roborazzi ./build/outputs/roborazzi/compareProdDebug
-      - gh/install
-      - run:
-          name: gh login
+          name: set github access token
           # Create GitHub App Token using JWT and pass it with gh auth to login
           # ref: https://zenn.dev/gorohash/articles/e2c5f6ce50f4e6
           command: |
@@ -128,9 +79,75 @@ jobs:
                 | jq -r ".token"
               )
             )
-            # ◼ gh auth login
-            echo gh auth login
-            echo "$access_token" | gh auth login --with-token
+            
+            # ◼ set github access token
+            echo "export GITHUB_ACCESS_TOKEN='$(access_token)'" >> $BASH_ENV
+
+jobs:
+  build-and-test-prod:
+    executor: android
+    steps:
+      - checkout
+      - gh/install
+      - set-github-access-token
+      - run:
+          name: gh login
+          command: echo "$GITHUB_ACCESS_TOKEN" | gh auth login --with-token
+      - run:
+          name: get base branch name
+          # ref: https://discuss.circleci.com/t/how-to-retrieve-a-pull-requests-base-branch-name-github/36911
+          command: |
+            # ◼ get base branch name
+            pr=$(echo https://api.github.com/repos/${CIRCLE_PULL_REQUEST:19} | sed "s/\/pull\//\/pulls\//")
+            echo "PR=${pr}"
+            base=$(curl -s -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" $pr | jq '.base.ref')
+            echo "BASE_BRANCH_NAME=${base}"
+            echo "export BASE_BRANCH_NAME=${base}" >> $BASH_ENV
+      - set-locale-properties
+      - restore-and-save-gradle-cache
+      - run:
+          neme: gem install bundler
+          command: sudo gem install bundler:2.4.12
+      - run:
+          # Specify Gemfile path and then run bundle install
+          name: bundle install
+          command: |
+            bundle config set --local path 'vendor/bundle'
+            bundle install
+      - run:
+          name: ktlint-check
+          command: ./gradlew --continue ktlintCheck
+      - run:
+          name: test
+          command: ./gradlew testProdDebug --stacktrace
+      - aws-cli/setup:
+          aws_access_key_id: AWS_ACCESS_KEY_ID
+          aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+          region: AWS_REGION
+      - aws-s3/copy:
+          arguments: --recursive
+          ## TODO: マージ先のブランチ名から持ってくる
+          from: s3://hiraganaconverter-roborazzi/image
+          to: ./app/build/outputs/roborazzi
+      - run:
+          name: compare screenshots
+          command: ./gradlew compareRoborazziProdDebug --stacktrace
+      - run:
+          name: jacoco-report
+          command: ./gradlew jacocoTestReport
+      - run:
+          name: jacoco-report to zip
+          command: zip -r jacocoTestReport.zip ./build/reports/jacoco/jacocoTestReport/html
+      - store_artifacts:
+          path: jacocoTestReport.zip
+      - run:
+          name: run-danger-file
+          command: bundle exec danger --verbose
+      - run:
+          name: move screenshots files
+          command: |
+            mkdir -p ./build/outputs/roborazzi/compareProdDebug
+            mv ./app/build/outputs/roborazzi ./build/outputs/roborazzi/compareProdDebug
       - run:
           name: create comments
           command: |
@@ -155,12 +172,6 @@ jobs:
       - run:
           name: test comment
           command: gh pr comment "$CIRCLE_PULL_REQUEST" --edit-last -F ./comments || gh pr comment "$CIRCLE_PULL_REQUEST" -F ./comments
-      - run:
-          name: create screenshots
-          command: ./gradlew recordRoborazziProdDebug --stacktrace
-      - aws-s3/sync:
-          from: ./app/build/outputs/roborazzi
-          to: s3://hiraganaconverter-roborazzi/image
       - slack/notify:
           event: fail
           template: basic_fail_1
@@ -181,6 +192,19 @@ jobs:
           event: fail
           template: basic_fail_1
 
+  save-screen-shot:
+    executor: android
+    steps:
+      - checkout
+      - set-locale-properties
+      - restore-and-save-gradle-cache
+      - run:
+          name: create screenshots
+          command: ./gradlew recordRoborazziMockDebug --stacktrace
+      - aws-s3/sync:
+          from: ./app/build/outputs/roborazzi
+          to: s3://hiraganaconverter-roborazzi/image/$CIRCLE_BRANCH
+
 workflows:
   test:
     jobs:
@@ -188,6 +212,12 @@ workflows:
           context: slack-secrets
       - build-mock:
           context: slack-secrets
-
+      - save-screen-shot:
+          filters:
+            branches:
+              only:
+                - main
+                - develop
+                - feature/circleci-roborazzi
 # ■ memo ■
 # check command： circleci config validate


### PR DESCRIPTION
## Issue
- #124

## Overview
- GitHub Appを使用してコメントを表示するようにした
- テストの画像についてはAWS S3を使った

## Reference
- [circleciデベロッパー - circleci/github-cli@2.3.0](https://circleci.com/developer/ja/orbs/orb/circleci/github-cli)
- [GitHub docs - GitHub App インストールとしての認証](https://docs.github.com/ja/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation)
- [Zenn - シェルスクリプトで GitHub App のインストールアクセストークンを取得する](https://zenn.dev/gorohash/articles/e2c5f6ce50f4e6)
- [GitHub docs - Generating an installation access token for a GitHub App](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app)
- [Zenn - JWT の仕組み](https://zenn.dev/mikakane/articles/tutorial_for_jwt)
- [Note - CircleCI から GitHub Apps 経由で Pull Request にコメントを投げる](https://note.com/weekly_report/n/n46f398a4a0f4#de8d2d77-3c08-4692-b2bb-8457450599de)
- [circleciデベロッパー - circleci/aws-s3@4.0.0](https://circleci.com/developer/ja/orbs/orb/circleci/aws-s3)
- [takahirom roborazzi-compare-on-github-comment-sample](https://github.com/takahirom/roborazzi-compare-on-github-comment-sample/blob/main/.github%2Fworkflows%2FCompareScreenshotComment.yml)