### PR TITLE
[リファクタ] Postアノテーションの引数変更

### DIFF
--- a/core/data/src/main/java/ksnd/hiraganaconverter/core/data/client/ConvertApiClient.kt
+++ b/core/data/src/main/java/ksnd/hiraganaconverter/core/data/client/ConvertApiClient.kt
@@ -8,6 +8,6 @@ import retrofit2.http.POST
 
 interface ConvertApiClient {
 
-    @POST(" ")
+    @POST(".")
     suspend fun requestConvert(@Body body: RequestBody): Response<ResponseData>
 }


### PR DESCRIPTION
## Overview
- `" "`は気持ち悪いとずっと思ってた
- 特にパスは必要なく現在地であることを表すために`"."`を使用した