### PR TITLE
[リファクタ] ConvertHistoryUiStateにImmutableアノテーションを設定 

### DIFF
--- a/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/ConvertHistoryUiState.kt
+++ b/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/ConvertHistoryUiState.kt
@@ -1,7 +1,9 @@
 package ksnd.hiraganaconverter.feature.history
 
+import androidx.compose.runtime.Immutable
 import ksnd.hiraganaconverter.core.model.ConvertHistoryData
 
+@Immutable
 data class ConvertHistoryUiState(
     val convertHistories: List<ConvertHistoryData> = emptyList(),
     val isShowDetailDialog: Boolean = false,


### PR DESCRIPTION
## Overview
- `./gradlew assembleProdRelease -PcomposeCompilerReports=true`を実行したときにUnstableだったため設定した