### PR TITLE
[VRT] DarkMode, LightModeの両方を表示できるようにする

### DIFF
--- a/app/src/test/java/ksnd/hiraganaconverter/PreviewTest.kt
+++ b/app/src/test/java/ksnd/hiraganaconverter/PreviewTest.kt
@@ -1,5 +1,8 @@
 package ksnd.hiraganaconverter
 
+import android.content.res.Configuration
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalConfiguration
 import com.airbnb.android.showkase.models.Showkase
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.github.takahirom.roborazzi.DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH
@@ -24,7 +27,16 @@ class PreviewTest(
         val componentName = showkaseBrowserComponent.componentName.replace(" ", "")
         val filePath = DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH + "/" + showkaseBrowserComponent.group + "_" + componentName + ".png"
         captureRoboImage(filePath) {
-            showkaseBrowserComponent.component()
+            val newConfiguration = Configuration().apply {
+                this.uiMode = if (componentName.contains(other = "dark", ignoreCase = true)) {
+                    Configuration.UI_MODE_NIGHT_YES
+                } else {
+                    Configuration.UI_MODE_NIGHT_NO
+                }
+            }
+            CompositionLocalProvider(LocalConfiguration provides newConfiguration) {
+                showkaseBrowserComponent.component()
+            }
         }
     }
 

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/BackTopBar.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/BackTopBar.kt
@@ -63,8 +63,8 @@ fun BackTopBar(
 @OptIn(ExperimentalMaterial3Api::class)
 @UiModePreview
 @Composable
-fun PreviewBackTopBar_Light() {
-    HiraganaConverterTheme(isDarkTheme = false) {
+fun PreviewBackTopBar() {
+    HiraganaConverterTheme {
         BackTopBar(TopAppBarDefaults.pinnedScrollBehavior()) {}
     }
 }

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/button/CustomButtonWithBackground.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/button/CustomButtonWithBackground.kt
@@ -3,7 +3,6 @@ package ksnd.hiraganaconverter.core.ui.parts.button
 import android.view.HapticFeedbackConstants.CONTEXT_CLICK
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.IconButton
@@ -60,7 +59,7 @@ fun CustomButtonWithBackground(
 @UiModePreview
 @Composable
 fun PreviewCustomButtonWithBackground() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         CustomButtonWithBackground(
             id = R.drawable.ic_reset,
             convertDescription = stringResource(id = R.string.conversion),

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/button/CustomRadioButton.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/button/CustomRadioButton.kt
@@ -2,7 +2,6 @@ package ksnd.hiraganaconverter.core.ui.parts.button
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
@@ -73,7 +72,7 @@ fun CustomRadioButton(
 @UiModePreview
 @Composable
 fun PreviewCustomThemeRadioButton() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         Surface(color = MaterialTheme.colorScheme.surfaceVariant) {
             CustomRadioButton(
                 buttonText = stringResource(id = R.string.dark_mode),

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/button/CustomlIconButton.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/button/CustomlIconButton.kt
@@ -1,7 +1,6 @@
 package ksnd.hiraganaconverter.core.ui.parts.button
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -64,7 +63,7 @@ fun CustomIconButton(
 @UiModePreview
 @Composable
 fun PreviewCustomIconButton() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         Surface(color = MaterialTheme.colorScheme.surface) {
             CustomIconButton(
                 contentDescription = "",

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/button/DeleteButton.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/button/DeleteButton.kt
@@ -1,7 +1,6 @@
 package ksnd.hiraganaconverter.core.ui.parts.button
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
@@ -71,7 +70,7 @@ fun DeleteButton(
 @UiModePreview
 @Composable
 fun PreviewDeleteButton() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         Surface(color = MaterialTheme.colorScheme.surface) {
             DeleteButton(onClick = {})
         }

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/button/MoveTopButton.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/button/MoveTopButton.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.slideIn
 import androidx.compose.animation.slideOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -65,7 +64,7 @@ fun MoveTopButton(scrollState: ScrollState) {
 @UiModePreview
 @Composable
 fun PreviewMoveTopButton_() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         val scrollState = rememberScrollState(initial = 1)
         Box(
             modifier = Modifier.padding(all = 16.dp),

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/button/TransitionButton.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/button/TransitionButton.kt
@@ -1,7 +1,6 @@
 package ksnd.hiraganaconverter.core.ui.parts.button
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
@@ -69,7 +68,7 @@ fun TransitionButton(
 @UiModePreview
 @Composable
 fun PreviewTransitionButton() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         Surface(color = MaterialTheme.colorScheme.surface) {
             TransitionButton(text = stringResource(R.string.oss_licenses), onClick = {})
         }

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/card/ConversionTypeCard.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/card/ConversionTypeCard.kt
@@ -1,7 +1,6 @@
 package ksnd.hiraganaconverter.core.ui.parts.card
 
 import android.view.HapticFeedbackConstants
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
@@ -81,7 +80,7 @@ private fun ConversionTypeSpinnerCardContent(selectedTextType: HiraKanaType) {
 @UiModePreview
 @Composable
 fun PreviewConversionTypeCard() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         ConversionTypeCard(onSelectedChange = {})
     }
 }

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/card/CovertHistoryCard.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/card/CovertHistoryCard.kt
@@ -1,7 +1,6 @@
 package ksnd.hiraganaconverter.core.ui.parts.card
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -102,7 +101,7 @@ private fun ConvertHistoryCardTimeText(timeText: String) {
 @UiModePreview
 @Composable
 fun PreviewConvertHistoryCard() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         ConvertHistoryCard(
             beforeText = "変換前文章",
             time = "2022/12/29 18:19",

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/card/LanguageCard.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/card/LanguageCard.kt
@@ -1,6 +1,5 @@
 package ksnd.hiraganaconverter.core.ui.parts.card
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -66,7 +65,7 @@ fun LanguageCard(
 @UiModePreview
 @Composable
 fun PreviewLanguageCard() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         Column(Modifier.fillMaxWidth()) {
             LanguageCard(
                 displayLanguage = stringResource(id = R.string.display_en),

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/card/TitleCard.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/card/TitleCard.kt
@@ -1,7 +1,6 @@
 package ksnd.hiraganaconverter.core.ui.parts.card
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
@@ -64,7 +63,7 @@ fun TitleCard(text: String, painter: Painter) {
 @UiModePreview
 @Composable
 fun PreviewTitleCard() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         TitleCard(text = "Title", painter = painterResource(id = R.drawable.ic_outline_info_24))
     }
 }

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/dialog/MovesToSiteDialog.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/parts/dialog/MovesToSiteDialog.kt
@@ -35,7 +35,7 @@ fun MovesToSiteDialog(onDismissRequest: () -> Unit, onClick: () -> Unit, url: St
 //@UiModePreview
 //@Composable
 //fun PreviewMovesToSiteDialog() {
-//    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+//    HiraganaConverterTheme {
 //        MovesToSiteDialog(
 //            onDismissRequest = {},
 //            onClick = {},

--- a/feature/converter/src/main/java/ksnd/hiraganaconverter/feature/converter/ConverterScreen.kt
+++ b/feature/converter/src/main/java/ksnd/hiraganaconverter/feature/converter/ConverterScreen.kt
@@ -3,7 +3,6 @@ package ksnd.hiraganaconverter.feature.converter
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -352,7 +351,7 @@ private fun BeforeOrAfterTextField(
 @UiModePreview
 @Composable
 fun PreviewConverterScreenContent() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         CompositionLocalProvider(LocalIsConnectNetwork provides false) {
             ConverterScreenContent(
                 uiState = ConvertUiState(

--- a/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/ConvertHistoryDetailDialog.kt
+++ b/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/ConvertHistoryDetailDialog.kt
@@ -3,7 +3,6 @@ package ksnd.hiraganaconverter.feature.history
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.border
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -170,7 +169,7 @@ private fun BeforeOrAfterText(
 @UiModePreview
 @Composable
 fun PreviewConvertHistoryDetailDialogContent() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         Box(modifier = Modifier.fillMaxSize()) {
             ConvertHistoryDetailDialogContent(
                 historyData = ConvertHistoryData(

--- a/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/ConvertHistoryScreen.kt
+++ b/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/ConvertHistoryScreen.kt
@@ -3,7 +3,6 @@ package ksnd.hiraganaconverter.feature.history
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -183,7 +182,7 @@ private fun EmptyHistoryImage() {
 @UiModePreview
 @Composable
 fun PreviewConvertHistoryScreeContent() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         Surface(
             color = MaterialTheme.colorScheme.surface,
             modifier = Modifier.fillMaxSize(),
@@ -203,7 +202,7 @@ fun PreviewConvertHistoryScreeContent() {
 @UiModePreview
 @Composable
 fun PreviewConvertHistoryScreenContent_NoData() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         Surface(
             color = MaterialTheme.colorScheme.surface,
             modifier = Modifier.fillMaxSize(),

--- a/feature/info/src/main/java/ksnd/hiraganaconverter/feature/info/InfoScreen.kt
+++ b/feature/info/src/main/java/ksnd/hiraganaconverter/feature/info/InfoScreen.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -357,7 +356,7 @@ private fun UrlText(url: String, onURLClick: () -> Unit) {
 @UiModePreview
 @Composable
 fun PreviewInfoScreenContent() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
             InfoScreenContent(
                 versionName = "1.0.0",

--- a/feature/setting/src/main/java/ksnd/hiraganaconverter/feature/setting/SelectLanguageDialog.kt
+++ b/feature/setting/src/main/java/ksnd/hiraganaconverter/feature/setting/SelectLanguageDialog.kt
@@ -3,7 +3,6 @@ package ksnd.hiraganaconverter.feature.setting
 import androidx.activity.compose.BackHandler
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.border
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -99,7 +98,7 @@ private fun SelectLanguageDialogContent(
 @UiModePreview
 @Composable
 fun PreviewSelectLanguageDialogContent() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
             SelectLanguageDialogContent(
                 onCloseClick = {},

--- a/feature/setting/src/main/java/ksnd/hiraganaconverter/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/ksnd/hiraganaconverter/feature/setting/SettingScreen.kt
@@ -1,7 +1,6 @@
 package ksnd.hiraganaconverter.feature.setting
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -217,7 +216,7 @@ private fun SettingFontContent(
 @UiModePreview
 @Composable
 fun PreviewSettingScreenContent() {
-    HiraganaConverterTheme(isDarkTheme = isSystemInDarkTheme()) {
+    HiraganaConverterTheme {
         Surface(
             modifier = Modifier.fillMaxSize(),
         ) {


### PR DESCRIPTION
## Issue
- fix #418 

## Overview
- PreviewはHiraganaConverterThemeを囲んでいて、darkかlightは内部のLocalConfiguration.current.uiModeで決まっているから、CompositionLocalProviderで直接定義してあげるようにした
- DarkかLightかはcomponentNameにdarkがついていたらっていう判定にした（DroidKaigiのように複数パラメータあるわけじゃないし、設定なくともいいかなと思った）

## Ref
https://github.com/DroidKaigi/conference-app-2023
PRの`649`を参考にした