### PR TITLE
feature: apply to webp with PreviewTest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,13 +200,13 @@ commands:
             if [ $IS_SKIPPING_VRT = "false" ]; then
               git push origin --delete compare_$CIRCLE_BRANCH || true
             
-              fileSize=$(echo $(find ./screenshots/compare -type f | grep -e '.*_compare.png' | wc -l | sed -e 's/ //g'))
+              fileSize=$(echo $(find ./screenshots/compare -type f | grep -e '.*_compare.webp' | wc -l | sed -e 's/ //g'))
               echo "fileSize: $fileSize"
               if [ $fileSize -ne 0 ]; then
                 git checkout --orphan compare_$CIRCLE_BRANCH
                 git rm --cached -rf .
             
-                add_files=$(find . -type f -path "./screenshots/compare/*" -name "*_compare.png")
+                add_files=$(find . -type f -path "./screenshots/compare/*" -name "*_compare.webp")
                 for file in $add_files; do
                   git add -f $file
                 done
@@ -229,7 +229,7 @@ commands:
             echo "| File name | Image |" >> comment
             echo "|-------|-------|" >> comment
             
-            files=$(find . -type f -path "./screenshots/compare/*" -name "*_compare.png")
+            files=$(find . -type f -path "./screenshots/compare/*" -name "*_compare.webp")
             for file in $files; do
               fileName=$(basename "$file" | sed -r 's/(.{20})/\1<br>/g')
               echo "| [$fileName](https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/blob/compare_$CIRCLE_BRANCH/$file) | ![](https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/blob/compare_$CIRCLE_BRANCH/$file?raw=true) |" >> comment

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -178,6 +178,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)
     testImplementation(libs.composable.preview.scanner)
+    testImplementation(libs.webp.image.io)
 }
 
 tasks.withType<Test>().configureEach {

--- a/app/src/test/java/ksnd/hiraganaconverter/RoborazziComposePreviewTest.kt
+++ b/app/src/test/java/ksnd/hiraganaconverter/RoborazziComposePreviewTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onRoot
 import androidx.test.core.app.ApplicationProvider
 import com.github.takahirom.roborazzi.ComposePreviewTester
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.LosslessWebPImageIoFormat
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.captureRoboImage
 import org.robolectric.RuntimeEnvironment
@@ -49,7 +50,7 @@ class RoborazziComposePreviewTest : ComposePreviewTester<AndroidPreviewInfo> {
 
     override fun test(preview: ComposablePreview<AndroidPreviewInfo>) {
         val screenshotId = AndroidPreviewScreenshotIdBuilder(preview).build()
-        val filePath = "$SCREEN_SHOT_PATH$screenshotId.png"
+        val filePath = "$SCREEN_SHOT_PATH$screenshotId.webp"
 
         preview.apply {
             if (this.previewInfo.uiMode == Configuration.UI_MODE_NIGHT_YES) {
@@ -72,6 +73,9 @@ class RoborazziComposePreviewTest : ComposePreviewTester<AndroidPreviewInfo> {
                 roborazziOptions = RoborazziOptions(
                     compareOptions = RoborazziOptions.CompareOptions(
                         outputDirectoryPath = COMPARE_PATH,
+                    ),
+                    recordOptions = RoborazziOptions.RecordOptions(
+                        imageIoFormat = LosslessWebPImageIoFormat(),
                     ),
                 ),
             )

--- a/feature/converter/src/main/java/ksnd/hiraganaconverter/feature/converter/ConverterScreen.kt
+++ b/feature/converter/src/main/java/ksnd/hiraganaconverter/feature/converter/ConverterScreen.kt
@@ -379,7 +379,7 @@ fun PreviewConverterScreenContent(
 
 class PreviewConverterUiStateProvider : PreviewParameterProvider<ConvertUiState> {
     override val values: Sequence<ConvertUiState> = sequenceOf(
-        ConvertUiState(inputText = "漢字漢字", outputText = "かんじかんじ"),
+        ConvertUiState(inputText = "漢字", outputText = "かんじ"),
         ConvertUiState(showErrorCard = true, convertErrorType = ConvertErrorType.REACHED_CONVERT_MAX_LIMIT),
     )
 }

--- a/feature/converter/src/main/java/ksnd/hiraganaconverter/feature/converter/ConverterScreen.kt
+++ b/feature/converter/src/main/java/ksnd/hiraganaconverter/feature/converter/ConverterScreen.kt
@@ -379,7 +379,7 @@ fun PreviewConverterScreenContent(
 
 class PreviewConverterUiStateProvider : PreviewParameterProvider<ConvertUiState> {
     override val values: Sequence<ConvertUiState> = sequenceOf(
-        ConvertUiState(inputText = "漢字", outputText = "かんじ"),
+        ConvertUiState(inputText = "漢字漢字", outputText = "かんじかんじ"),
         ConvertUiState(showErrorCard = true, convertErrorType = ConvertErrorType.REACHED_CONVERT_MAX_LIMIT),
     )
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 org.gradle.caching=true
+
+roborazzi.record.image.extension=webp

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ roborazzi = "1.32.2"
 aboutLibraries = "11.2.3"
 konsist = "0.16.1"
 composablePreviewScanner = "0.4.0"
+webpImageIO = "0.3.3"
 
 # ** I'm using it, so no deletions allowed. **
 jacoco = "0.8.10"
@@ -159,6 +160,9 @@ aboutLibraries = { group = "com.mikepenz", name = "aboutlibraries-compose-m3", v
 
 # Konsist
 konsist = { group = "com.lemonappdev", name = "konsist", version.ref = "konsist" }
+
+# WebP ImageIO
+webp-image-io = { group = "io.github.darkxanter", name = "webp-imageio", version.ref = "webpImageIO" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
## Reference
- https://github.com/takahirom/roborazzi?tab=readme-ov-file#experimental-webp-support-and-other-image-formats

## Result (65 sheets,  60% reduction )
- OLD
  - 2,973,003 bytes（3.1 MB）
- NEW
  - 1,202,622 bytes（1.3 MB）

