### PR TITLE
feature: use SharedElementTransition in ConvertHisotryDetail

### DIFF
--- a/app/src/main/java/ksnd/hiraganaconverter/view/MainActivity.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/MainActivity.kt
@@ -11,6 +11,8 @@ import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.SnackbarDuration
@@ -37,6 +39,7 @@ import ksnd.hiraganaconverter.core.domain.inappreview.InAppReviewManager
 import ksnd.hiraganaconverter.core.model.ui.Theme
 import ksnd.hiraganaconverter.core.resource.R
 import ksnd.hiraganaconverter.core.ui.LocalIsConnectNetwork
+import ksnd.hiraganaconverter.core.ui.LocalSharedTransitionScope
 import ksnd.hiraganaconverter.core.ui.theme.HiraganaConverterTheme
 import ksnd.hiraganaconverter.core.ui.theme.LocalIsDarkTheme
 import ksnd.hiraganaconverter.view.navigation.Navigation
@@ -67,6 +70,7 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+    @OptIn(ExperimentalSharedTransitionApi::class)
     @AddTrace(name = "MainActivity#onCreate")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -144,25 +148,28 @@ class MainActivity : AppCompatActivity() {
                 }
             }
 
-            CompositionLocalProvider(
-                LocalAnalytics provides analytics,
-                LocalIsConnectNetwork provides uiState.isConnectNetwork,
-                LocalIsDarkTheme provides isDarkTheme,
-            ) {
-                HiraganaConverterTheme(
-                    isDarkTheme = isDarkTheme,
-                    fontType = uiState.fontType,
+            SharedTransitionLayout {
+                CompositionLocalProvider(
+                    LocalAnalytics provides analytics,
+                    LocalIsConnectNetwork provides uiState.isConnectNetwork,
+                    LocalIsDarkTheme provides isDarkTheme,
+                    LocalSharedTransitionScope provides this@SharedTransitionLayout,
                 ) {
-                    Column {
-                        InAppUpdateDownloadingCard(
-                            text = this@MainActivity.getString(R.string.in_app_update_downloading_snackbar_title, downloadPercentage),
-                            isVisible = uiState.inAppUpdateState is InAppUpdateState.Downloading,
-                        )
-                        Navigation(
-                            modifier = Modifier.weight(1f),
-                            snackbarHostState = snackbarHostState,
-                            receivedText = receivedText,
-                        )
+                    HiraganaConverterTheme(
+                        isDarkTheme = isDarkTheme,
+                        fontType = uiState.fontType,
+                    ) {
+                        Column {
+                            InAppUpdateDownloadingCard(
+                                text = this@MainActivity.getString(R.string.in_app_update_downloading_snackbar_title, downloadPercentage),
+                                isVisible = uiState.inAppUpdateState is InAppUpdateState.Downloading,
+                            )
+                            Navigation(
+                                modifier = Modifier.weight(1f),
+                                snackbarHostState = snackbarHostState,
+                                receivedText = receivedText,
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/ksnd/hiraganaconverter/view/navigation/Navigation.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/navigation/Navigation.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.dropUnlessResumed
@@ -30,6 +31,7 @@ import androidx.navigation.toRoute
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import ksnd.hiraganaconverter.core.model.ConvertHistoryData
+import ksnd.hiraganaconverter.core.ui.LocalAnimatedVisibilityScope
 import ksnd.hiraganaconverter.core.ui.navigation.Nav
 import ksnd.hiraganaconverter.feature.converter.ConverterScreen
 import ksnd.hiraganaconverter.feature.history.ConvertHistoryScreen
@@ -77,19 +79,27 @@ fun Navigation(
             )
         }
         slideHorizontallyComposable<Nav.History> {
-            ConvertHistoryScreen(
-                viewModel = hiltViewModel(),
-                navigateHistoryDetail = ::navigateHistoryDetail,
-                onBackPressed = dropUnlessResumed(block = navController::navigateUp),
-            )
+            CompositionLocalProvider(
+                LocalAnimatedVisibilityScope provides this,
+            ) {
+                ConvertHistoryScreen(
+                    viewModel = hiltViewModel(),
+                    navigateHistoryDetail = ::navigateHistoryDetail,
+                    onBackPressed = dropUnlessResumed(block = navController::navigateUp),
+                )
+            }
         }
         slideHorizontallyComposable<Nav.HistoryDetail>(
             typeMap = mapOf(typeOf<ConvertHistoryData>() to serializableType<ConvertHistoryData>()),
         ) {
-            ConvertHistoryDetailScreen(
-                historyData = it.toRoute<Nav.HistoryDetail>().historyData,
-                onBackPressed = dropUnlessResumed(block = navController::navigateUp),
-            )
+            CompositionLocalProvider(
+                LocalAnimatedVisibilityScope provides this,
+            ) {
+                ConvertHistoryDetailScreen(
+                    history = it.toRoute<Nav.HistoryDetail>().historyData,
+                    onBackPressed = dropUnlessResumed(block = navController::navigateUp),
+                )
+            }
         }
         slideHorizontallyComposable<Nav.Setting> {
             SettingScreen(

--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -63,6 +63,7 @@
     <string name="app_name_title" translatable="false">App Name</string>
     <string name="ok" translatable="false">OK</string>
     <string name="cancel" translatable="false">Cancel</string>
+    <string name="time" translatable="false">Time :</string>
 
     <string name="developer_name_title" translatable="false">Developer</string>
     <string name="developer_name" translatable="false">KSND</string>

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/AnimatedVisibilityScope.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/AnimatedVisibilityScope.kt
@@ -1,0 +1,7 @@
+package ksnd.hiraganaconverter.core.ui
+
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.runtime.compositionLocalOf
+
+// ref: https://docs.google.com/presentation/d/1kmKLeTsic2Fixxu63xFjVwu5wE1AC07HzGvD5mS9T0o/edit#slide=id.g2f7714da44f_0_728
+val LocalAnimatedVisibilityScope = compositionLocalOf<AnimatedVisibilityScope> { error("Not initialize AnimatedVisibilityScope") }

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/LocalSharedTransitionScope.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/LocalSharedTransitionScope.kt
@@ -1,0 +1,9 @@
+package ksnd.hiraganaconverter.core.ui
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.runtime.staticCompositionLocalOf
+
+// ref: https://docs.google.com/presentation/d/1kmKLeTsic2Fixxu63xFjVwu5wE1AC07HzGvD5mS9T0o/edit#slide=id.g2f7714da44f_0_739
+@OptIn(ExperimentalSharedTransitionApi::class)
+val LocalSharedTransitionScope = staticCompositionLocalOf<SharedTransitionScope> { error("Not initialized SharedTransitionScope") }

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/SharedKeys.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/SharedKeys.kt
@@ -1,0 +1,12 @@
+package ksnd.hiraganaconverter.core.ui
+
+data class ConvertHistorySharedKey(
+    val id: Long,
+    val type: SharedType,
+    val origin: String = "convertHistory",
+)
+
+enum class SharedType {
+    CONVERT_TIME,
+    BEFORE_TEXT,
+}

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/extension/EasySharedBounds.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/extension/EasySharedBounds.kt
@@ -1,0 +1,19 @@
+package ksnd.hiraganaconverter.core.ui.extension
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import ksnd.hiraganaconverter.core.ui.LocalAnimatedVisibilityScope
+import ksnd.hiraganaconverter.core.ui.LocalSharedTransitionScope
+
+// ref: https://docs.google.com/presentation/d/1kmKLeTsic2Fixxu63xFjVwu5wE1AC07HzGvD5mS9T0o/edit#slide=id.g2f7714da44f_0_749
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun Modifier.easySharedBounds(key: Any): Modifier {
+    with(LocalSharedTransitionScope.current) {
+        return this@easySharedBounds.sharedBounds(
+            sharedContentState = rememberSharedContentState(key = key),
+            animatedVisibilityScope = LocalAnimatedVisibilityScope.current,
+        )
+    }
+}

--- a/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/preview/SharedTransitionAndAnimatedVisibilityProvider.kt
+++ b/core/ui/src/main/java/ksnd/hiraganaconverter/core/ui/preview/SharedTransitionAndAnimatedVisibilityProvider.kt
@@ -1,0 +1,25 @@
+package ksnd.hiraganaconverter.core.ui.preview
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import ksnd.hiraganaconverter.core.ui.LocalAnimatedVisibilityScope
+import ksnd.hiraganaconverter.core.ui.LocalSharedTransitionScope
+
+// ref: https://stackoverflow.com/questions/78656716/jetpack-compose-preview-for-screen-that-have-sharedtransitionscope-animatedvisi
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun SharedTransitionAndAnimatedVisibilityProvider(content: @Composable () -> Unit) {
+    SharedTransitionLayout {
+        AnimatedVisibility(visible = true) {
+            CompositionLocalProvider(
+                LocalSharedTransitionScope provides this@SharedTransitionLayout,
+                LocalAnimatedVisibilityScope provides this@AnimatedVisibility,
+            ) {
+                content()
+            }
+        }
+    }
+}

--- a/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/ConvertHistoryScreen.kt
+++ b/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/ConvertHistoryScreen.kt
@@ -61,7 +61,7 @@ import ksnd.hiraganaconverter.core.resource.R
 import ksnd.hiraganaconverter.core.ui.extension.noRippleClickable
 import ksnd.hiraganaconverter.core.ui.parts.BackTopBar
 import ksnd.hiraganaconverter.core.ui.parts.button.CustomIconButton
-import ksnd.hiraganaconverter.core.ui.parts.card.ConvertHistoryCard
+import ksnd.hiraganaconverter.core.ui.preview.SharedTransitionAndAnimatedVisibilityProvider
 import ksnd.hiraganaconverter.core.ui.preview.UiModePreview
 import ksnd.hiraganaconverter.core.ui.theme.HiraganaConverterTheme
 
@@ -163,8 +163,7 @@ private fun ConvertHistoryScreenContent(
                     ) { history ->
                         ConvertHistoryCard(
                             modifier = Modifier.padding(horizontal = 16.dp),
-                            beforeText = history.before,
-                            time = history.time,
+                            history = history,
                             onClick = { navigateHistoryDetail(history) },
                             onDeleteClick = { deleteConvertHistory(history) },
                         )
@@ -239,17 +238,19 @@ fun PreviewConvertHistoryScreeContent(
     @PreviewParameter(PreviewConverterHistoryUiStateProvider::class) state: ConvertHistoryUiState,
 ) {
     HiraganaConverterTheme {
-        Surface(
-            color = MaterialTheme.colorScheme.surface,
-            modifier = Modifier.fillMaxSize(),
-        ) {
-            ConvertHistoryScreenContent(
-                state = state,
-                onBackPressed = {},
-                deleteAllConvertHistory = {},
-                deleteConvertHistory = {},
-                navigateHistoryDetail = {},
-            )
+        SharedTransitionAndAnimatedVisibilityProvider {
+            Surface(
+                color = MaterialTheme.colorScheme.surface,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                ConvertHistoryScreenContent(
+                    state = state,
+                    onBackPressed = {},
+                    deleteAllConvertHistory = {},
+                    deleteConvertHistory = {},
+                    navigateHistoryDetail = {},
+                )
+            }
         }
     }
 }

--- a/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/ConvertHistoryTimeText.kt
+++ b/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/ConvertHistoryTimeText.kt
@@ -1,0 +1,38 @@
+package ksnd.hiraganaconverter.feature.history
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import ksnd.hiraganaconverter.core.model.ConvertHistoryData
+import ksnd.hiraganaconverter.core.model.mock.MockConvertHistoryData
+import ksnd.hiraganaconverter.core.ui.ConvertHistorySharedKey
+import ksnd.hiraganaconverter.core.ui.SharedType
+import ksnd.hiraganaconverter.core.ui.extension.easySharedBounds
+import ksnd.hiraganaconverter.core.ui.preview.SharedTransitionAndAnimatedVisibilityProvider
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun ConvertHistoryTimeText(
+    history: ConvertHistoryData,
+    modifier: Modifier = Modifier,
+    style: TextStyle = MaterialTheme.typography.bodySmall,
+) {
+    Text(
+        modifier = modifier.easySharedBounds(ConvertHistorySharedKey(id = history.id, type = SharedType.CONVERT_TIME)),
+        text = history.time,
+        style = style,
+        color = MaterialTheme.colorScheme.secondary,
+    )
+}
+
+@Preview
+@Composable
+fun PreviewConvertHistoryTimeText() {
+    SharedTransitionAndAnimatedVisibilityProvider {
+        ConvertHistoryTimeText(history = MockConvertHistoryData().data.first())
+    }
+}

--- a/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/CovertHistoryCard.kt
+++ b/feature/history/src/main/java/ksnd/hiraganaconverter/feature/history/CovertHistoryCard.kt
@@ -1,9 +1,9 @@
-package ksnd.hiraganaconverter.core.ui.parts.card
+package ksnd.hiraganaconverter.feature.history
 
+import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -23,20 +23,27 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import ksnd.hiraganaconverter.core.model.ConvertHistoryData
+import ksnd.hiraganaconverter.core.model.mock.MockConvertHistoryData
+import ksnd.hiraganaconverter.core.ui.ConvertHistorySharedKey
+import ksnd.hiraganaconverter.core.ui.SharedType
+import ksnd.hiraganaconverter.core.ui.extension.easySharedBounds
 import ksnd.hiraganaconverter.core.ui.extension.noRippleClickable
+import ksnd.hiraganaconverter.core.ui.preview.SharedTransitionAndAnimatedVisibilityProvider
 import ksnd.hiraganaconverter.core.ui.preview.UiModePreview
 import ksnd.hiraganaconverter.core.ui.rememberButtonScaleState
 import ksnd.hiraganaconverter.core.ui.theme.HiraganaConverterTheme
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun ConvertHistoryCard(
     modifier: Modifier = Modifier,
-    beforeText: String,
-    time: String,
+    history: ConvertHistoryData,
     onClick: () -> Unit,
     onDeleteClick: () -> Unit,
 ) {
     val buttonScaleState = rememberButtonScaleState()
+
     Card(
         modifier = modifier
             .wrapContentHeight()
@@ -56,9 +63,13 @@ fun ConvertHistoryCard(
                     .padding(all = 8.dp)
                     .weight(1f),
             ) {
-                ConvertHistoryCardTimeText(timeText = time)
+                ConvertHistoryTimeText(
+                    history = history,
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
                 Text(
-                    text = beforeText,
+                    text = history.before,
+                    modifier = Modifier.easySharedBounds(ConvertHistorySharedKey(id = history.id, type = SharedType.BEFORE_TEXT)),
                     maxLines = 2,
                     minLines = 2,
                     style = MaterialTheme.typography.bodyMedium,
@@ -82,30 +93,16 @@ fun ConvertHistoryCard(
     }
 }
 
-@Composable
-private fun ConvertHistoryCardTimeText(timeText: String) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            modifier = Modifier.padding(end = 8.dp),
-            text = timeText,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.secondary,
-        )
-        Spacer(modifier = Modifier.weight(1f))
-    }
-}
-
 @UiModePreview
 @Composable
 fun PreviewConvertHistoryCard() {
-    HiraganaConverterTheme {
-        ConvertHistoryCard(
-            beforeText = "変換前文章",
-            time = "2022/12/29 18:19",
-            onClick = {},
-            onDeleteClick = {},
-        )
+    SharedTransitionAndAnimatedVisibilityProvider {
+        HiraganaConverterTheme {
+            ConvertHistoryCard(
+                history = MockConvertHistoryData().data[0],
+                onClick = {},
+                onDeleteClick = {},
+            )
+        }
     }
 }


### PR DESCRIPTION
## Reference
- [Android developers - Shared Element Transitions in Compose](https://developer.android.com/develop/ui/compose/animation/shared-elements?hl=en)
- [Jetpack ComposeにおけるShared Element Transitionsの実例と導入方法 またその仕組み](https://2024.droidkaigi.jp/timetable/693259/)
- [stack overflow - Jetpack compose preview for screen that have SharedTransitionScope, AnimatedVisibilityScope as parameter](https://stackoverflow.com/questions/78656716/jetpack-compose-preview-for-screen-that-have-sharedtransitionscope-animatedvisi)

