### PR TITLE
feature: add showing end of service noticing dialog

### DIFF
--- a/app/src/main/java/ksnd/hiraganaconverter/view/MainActivity.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/MainActivity.kt
@@ -15,9 +15,12 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -26,12 +29,14 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.res.stringResource
 import androidx.core.app.ShareCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.firebase.perf.metrics.AddTrace
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import ksnd.hiraganaconverter.BuildConfig
 import ksnd.hiraganaconverter.core.analytics.AnalyticsHelper
 import ksnd.hiraganaconverter.core.analytics.LocalAnalytics
 import ksnd.hiraganaconverter.core.data.inappupdate.InAppUpdateState
@@ -181,6 +186,19 @@ class MainActivity : AppCompatActivity() {
                     onOk = {
                         coroutineScope.launch { inAppReviewManager.requestReview() }
                         mainViewModel.completedRequestReview()
+                    },
+                )
+            }
+
+            if (BuildConfig.DEBUG.not() && uiState.isShowedEndOfService.not()) {
+                AlertDialog(
+                    onDismissRequest = { /* no-op */ },
+                    title = { Text(text = stringResource(id = R.string.end_of_service_title)) },
+                    text = { Text(text = stringResource(id = R.string.end_of_service_body)) },
+                    confirmButton = {
+                        TextButton(onClick = mainViewModel::finishedToShowEndOfService) {
+                            Text(text = stringResource(id = R.string.ok))
+                        }
                     },
                 )
             }

--- a/app/src/main/java/ksnd/hiraganaconverter/view/MainActivityUiState.kt
+++ b/app/src/main/java/ksnd/hiraganaconverter/view/MainActivityUiState.kt
@@ -10,4 +10,5 @@ data class MainActivityUiState(
     val inAppUpdateState: InAppUpdateState = InAppUpdateState.Requesting,
     val isRequestingReview: Boolean = false,
     val isConnectNetwork: Boolean? = null,
+    val isShowedEndOfService: Boolean = false,
 )

--- a/core/resource/src/main/res/values-ja/strings.xml
+++ b/core/resource/src/main/res/values-ja/strings.xml
@@ -18,6 +18,8 @@
     <string name="font_setting">フォント</string>
     <string name="top">Top</string>
     <string name="not_connected_network">ネットワークに接続していません…</string>
+    <string name="end_of_service_title">サービス終了のお知らせ</string>
+    <string name="end_of_service_body">APIのサービス廃止に伴いまして2025年3月3日よりアプリでの変換処理は利用できなくなります。</string>
 
     <string name="conversion_failed">変換に失敗しました。</string>
     <string name="request_too_large">文字数が多すぎます。文字数を減らして再度変換してください。</string>

--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -78,6 +78,8 @@
     <string name="privacy_policy_title" translatable="false">Privacy</string>
     <string name="privacy_policy_button" translatable="false">Privacy Policy</string>
     <string name="privacy_policy_url" translatable="false">https://kosenda.github.io/ksnd.github.io/HiraganaConverter.html</string>
+    <string name="end_of_service_title">Notice of Service Discontinuation</string>
+    <string name="end_of_service_body">With the discontinuation of the API service, the conversion process will not be available after March 3, 2025.</string>
 
     <!-- Locale Name -->
     <string name="locale_en" translatable="false">en</string>


### PR DESCRIPTION
https://labs.goo.ne.jp/api/end_of_goolab_202501
> 「gooラボ」終了のお知らせ
> 平素より「gooラボ」をご利用いただき、誠にありがとうございます。
> 
> このたび、「gooラボ」は、2025年3月26日をもって終了することとなりました。
> また、提供中のgooラボAPIは、2025年3月3日に終了いたします。
> 長年に渡り多くのお客様にご利用いただき深くお礼申し上げます。
> 
> ■「gooラボ」終了までのスケジュール
>    ・2025/3/3  （月）午前11:00　gooラボAPIの停止
>    ・2025/3/26（水）午前11:00　gooラボ終了